### PR TITLE
feat(#6): add Swiss Nihilism design system docs to CLAUDE.md; sync docs/index.html to web/index.html

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,48 @@ Thomas Frumkin's design from the AI Craftspeople Guild.
 - `src/hushbell/spectrum.py` -- Real-time FFT visualiser with dynamic markers
 - `src/hushbell/triggers/` -- Input sources (keyboard, MQTT, HTTP)
 - `tests/` -- Pytest suite with FFT verification (87 tests)
-- `web/` -- Browser demo (Web Audio API, frequency controls)
+- `web/` -- Browser demo (Web Audio API, frequency controls); `docs/index.html` is kept identical
+
+## Design System — Swiss Nihilism (ENTER Konsult)
+
+`web/index.html` and `docs/index.html` are **always identical**. Both follow Swiss Nihilism design language:
+
+- **No border-radius.** 0px on every element.
+- **No box-shadow.** Borders carry all depth signalling.
+- **Monospace hierarchy.** Labels: `'Courier New', monospace; font-size: 11-13px; text-transform: uppercase; letter-spacing: 0.08-0.12em`.
+- **System fonts for body.** `-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif`.
+- **Orange accent.** `#ea580c` (light/dark), `#996F00` (neutral). Never deviate.
+- **All colours via CSS custom properties.** `--bg`, `--surface`, `--border`, `--text`, `--text-muted`, `--accent`, `--amber`.
+
+### Themes
+
+| Theme | `--bg` | `--accent` |
+|-------|--------|-----------|
+| `light` | `#EAEAEA` | `#ea580c` |
+| `neutral` | `#F0EDE8` | `#996F00` |
+| `dark` | `#1e1e1e` | `#ea580c` |
+
+Theme stored in `localStorage`, auto-detected from `prefers-color-scheme` on first visit.
+
+### Emergent UI Pattern
+
+Cards hidden (`opacity:0; max-height:0`) until behaviour rules fire:
+
+| Card | Trigger |
+|------|---------|
+| Suggestion | 3 s idle, 0 rings |
+| Battery Projection | 3+ rings |
+| Frequency Education | Scroll to spectrum + 1+ ring |
+| Comparison | 5+ rings |
+
+Rules: `EMERGENT_RULES` array with `condition(ctx) / action(ctx)` pairs, evaluated on ring, scroll, and a 2 s interval.
+
+### Web Audio Patterns
+
+- Signal chain: `AudioContext → OscillatorNode → GainNode → AnalyserNode → destination`
+- FFT: `fftSize = 2048`, `smoothingTimeConstant = 0.75`, drawn at 60 fps via `requestAnimationFrame`
+- Frequency resolution mirrors `src/hushbell/config.py`: fixed / random / preset / vagal modes
+- Envelopes: linear, approximated-sine, approximated-exponential — all guarantee zero onset (anti-startle safety guarantee)
 
 ## Key Parameters
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -177,6 +177,46 @@
   .ring-btn:active { opacity: 0.85; }
   .ring-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
+  /* ─── FREQUENCY CONTROLS ───────────────────── */
+  .freq-controls { display: flex; flex-direction: column; gap: 12px; }
+
+  .freq-row {
+    display: flex; align-items: center; gap: 12px;
+  }
+
+  .freq-row label {
+    font-family: 'Courier New', monospace;
+    font-size: 13px; color: var(--text-muted); min-width: 80px;
+  }
+
+  .freq-row select, .freq-row input[type="range"] {
+    flex: 1;
+    font-family: 'Courier New', monospace; font-size: 13px;
+    background: var(--bg); color: var(--text);
+    border: 1px solid var(--border); padding: 4px 6px;
+  }
+
+  .freq-row .range-val {
+    font-family: 'Courier New', monospace; font-size: 13px;
+    color: var(--accent); min-width: 55px; text-align: right;
+  }
+
+  .preset-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+
+  .preset-chip {
+    font-family: 'Courier New', monospace; font-size: 11px;
+    padding: 3px 8px; border: 1px solid var(--border);
+    background: var(--bg); color: var(--text-muted);
+    cursor: pointer; transition: all 0.1s;
+  }
+
+  .preset-chip.active {
+    border-color: var(--accent); color: var(--accent); background: var(--surface);
+  }
+
+  .sub-controls { display: none; }
+  .sub-controls.visible { display: flex; flex-direction: column; gap: 8px; }
+
   /* Battery */
   .battery-row { display: flex; align-items: center; gap: 12px; }
   .battery-bar-wrap { flex: 1; height: 14px; border: 1px solid var(--border); background: var(--bg); }
@@ -217,41 +257,19 @@
 
   /* ─── EMERGENT UI CARDS ────────────────────── */
   .emergent-card {
-    background: var(--emergent-bg);
-    border: 1px solid var(--emergent-border);
-    border-left: 3px solid var(--accent);
-    padding: 16px 20px;
-    font-size: 14px;
-    line-height: 1.5;
-    opacity: 0;
-    max-height: 0;
-    overflow: hidden;
+    background: var(--emergent-bg); border: 1px solid var(--emergent-border);
+    border-left: 3px solid var(--accent); padding: 16px 20px;
+    font-size: 14px; line-height: 1.5;
+    opacity: 0; max-height: 0; overflow: hidden;
     transition: opacity 0.4s ease, max-height 0.4s ease, padding 0.4s ease, margin 0.4s ease;
-    margin: 0;
-    padding-top: 0; padding-bottom: 0;
+    margin: 0; padding-top: 0; padding-bottom: 0;
   }
-
-  .emergent-card.visible {
-    opacity: 1;
-    max-height: 200px;
-    padding: 16px 20px;
-  }
-
-  .emergent-card .ec-label {
-    font-family: 'Courier New', monospace;
-    font-size: 10px;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--text-muted);
-    margin-bottom: 6px;
-  }
-
+  .emergent-card.visible { opacity: 1; max-height: 200px; padding: 16px 20px; }
+  .emergent-card .ec-label { font-family: 'Courier New', monospace; font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 6px; }
   .emergent-card .ec-body { color: var(--text); }
   .emergent-card .ec-body strong { color: var(--accent); }
-
   .emergent-card.projection { border-left-color: var(--amber); }
   .emergent-card.projection .ec-label { color: var(--amber); }
-
   .emergent-card.education { border-left-color: #0891b2; }
   .emergent-card.education .ec-label { color: #0891b2; }
 </style>
@@ -261,7 +279,7 @@
 <header>
   <div class="header-left">
     <h1>Hush<span>Bell</span></h1>
-    <div class="meta">BROWSER DEMO &nbsp;|&nbsp; WEB AUDIO API &nbsp;|&nbsp; NO DEPENDENCIES</div>
+    <div class="meta">BROWSER DEMO &nbsp;|&nbsp; WEB AUDIO API &nbsp;|&nbsp; ANTI-CONDITIONING</div>
   </div>
   <div class="theme-switcher" id="themeSwitcher">
     <button data-theme="light" title="Light theme">L</button>
@@ -276,14 +294,14 @@
   <div class="notice" id="noticeCard">
     <div class="notice-icon">&#x1F3A7;</div>
     <div class="notice-text">
-      <strong>Headphones required.</strong> The 40Hz tone is below what laptop speakers can produce. You will only hear and feel it through headphones or a subwoofer. The 2000Hz tone is audible on all devices.
+      <strong>Headphones required.</strong> The 40Hz tone is below what laptop speakers can produce. You will only hear and feel it through headphones or a subwoofer.
     </div>
   </div>
 
-  <!-- Emergent: Suggestion (shown after idle) -->
+  <!-- Emergent: Suggestion -->
   <div class="emergent-card" id="ec-suggestion">
     <div class="ec-label">Suggestion</div>
-    <div class="ec-body">Put on headphones and press <strong>Ring HushBell</strong> to experience both channels. The <strong>40Hz</strong> rumble is the one dogs cannot hear.</div>
+    <div class="ec-body">Put on headphones and press <strong>Ring HushBell</strong> to experience both channels. Try <strong>Random</strong> or <strong>Vagal</strong> mode to hear the anti-conditioning frequency variation.</div>
   </div>
 
   <!-- LED Strip -->
@@ -297,10 +315,74 @@
     </div>
   </div>
 
+  <!-- Frequency Anti-Conditioning Controls -->
+  <div class="card">
+    <div class="card-label">Frequency Mode — Anti-Conditioning</div>
+    <div class="freq-controls">
+      <div class="freq-row">
+        <label>Mode</label>
+        <select id="freqMode" onchange="onFreqModeChange()">
+          <option value="fixed">Fixed (2000Hz)</option>
+          <option value="random">Random</option>
+          <option value="preset">Preset Rotation</option>
+          <option value="vagal">Vagal (Pleasant)</option>
+        </select>
+      </div>
+      <div class="freq-row">
+        <label>Envelope</label>
+        <select id="envelopeType">
+          <option value="linear">Linear</option>
+          <option value="sine">Sine (smoother)</option>
+          <option value="exponential">Exponential (gentle)</option>
+        </select>
+      </div>
+      <div class="freq-row">
+        <label>Pleasant</label>
+        <select id="pleasantMode">
+          <option value="off">Off</option>
+          <option value="on">On (harmonics + vibrato)</option>
+        </select>
+      </div>
+
+      <div id="randomControls" class="sub-controls">
+        <div class="freq-row">
+          <label>Min Hz</label>
+          <input type="range" id="freqMin" min="500" max="3500" value="800" oninput="updateRangeLabel('freqMin','freqMinVal')">
+          <span class="range-val" id="freqMinVal">800 Hz</span>
+        </div>
+        <div class="freq-row">
+          <label>Max Hz</label>
+          <input type="range" id="freqMax" min="500" max="4000" value="3500" oninput="updateRangeLabel('freqMax','freqMaxVal')">
+          <span class="range-val" id="freqMaxVal">3500 Hz</span>
+        </div>
+      </div>
+
+      <div id="presetControls" class="sub-controls">
+        <div class="freq-row">
+          <label>Presets</label>
+          <div class="preset-chips" id="presetChips"></div>
+        </div>
+      </div>
+
+      <div id="vagalControls" class="sub-controls">
+        <div class="freq-row">
+          <label>Centre</label>
+          <input type="range" id="vagalCenter" min="500" max="1500" value="900" oninput="updateRangeLabel('vagalCenter','vagalCenterVal')">
+          <span class="range-val" id="vagalCenterVal">900 Hz</span>
+        </div>
+        <div class="freq-row">
+          <label>Spread</label>
+          <input type="range" id="vagalSpread" min="50" max="500" value="200" oninput="updateRangeLabel('vagalSpread','vagalSpreadVal')">
+          <span class="range-val" id="vagalSpreadVal">+/- 200</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Ring Button -->
   <button class="ring-btn" id="ringBtn" onclick="handleRing()">&#x25B6; Ring HushBell</button>
 
-  <!-- Emergent: Projection (shown after 3+ rings) -->
+  <!-- Emergent: Battery Projection -->
   <div class="emergent-card projection" id="ec-projection">
     <div class="ec-label">Battery Projection</div>
     <div class="ec-body" id="ec-projection-body"></div>
@@ -319,7 +401,7 @@
 
   <!-- FFT Analyser -->
   <div class="card">
-    <div class="card-label">Real-Time FFT Spectrum — Proving 40Hz + 2000Hz</div>
+    <div class="card-label">Real-Time FFT Spectrum</div>
     <canvas id="fft" width="688" height="140"></canvas>
     <div class="freq-markers">
       <span>0 Hz</span><span>500</span><span>1000</span><span>1500</span>
@@ -327,12 +409,12 @@
     </div>
   </div>
 
-  <!-- Emergent: Education (shown on scroll to spectrum) -->
+  <!-- Emergent: Education -->
   <div class="emergent-card education" id="ec-education">
     <div class="ec-label">Frequency Guide</div>
     <div class="ec-body">
       <strong style="color:#ea580c">Orange bars</strong> = 40Hz (below the 67Hz dog hearing floor — they hear nothing).
-      <strong style="color:#FFBF00">Amber bars</strong> = 2000Hz (fades in over 500ms — 25x slower than the startle threshold).
+      <strong style="color:#FFBF00">Amber bars</strong> = secondary tone (varies per ring in random/preset/vagal modes — defeats classical conditioning).
     </div>
   </div>
 
@@ -341,34 +423,35 @@
     <div class="card-label">Signal Status</div>
     <div class="status-row">
       <div class="stat">40Hz sine &nbsp;<strong id="s40">IDLE</strong></div>
-      <div class="stat">2000Hz sine &nbsp;<strong id="s2k">IDLE</strong></div>
+      <div class="stat">Secondary &nbsp;<strong id="s2k">IDLE</strong></div>
+      <div class="stat">Freq &nbsp;<strong id="sFreq">—</strong></div>
       <div class="stat">Fade-in &nbsp;<strong id="sFade">—</strong></div>
       <div class="stat">Duration &nbsp;<strong id="sDur">—</strong></div>
     </div>
   </div>
 
-  <!-- Emergent: Comparison (shown after 5+ rings) -->
+  <!-- Emergent: Comparison -->
   <div class="emergent-card" id="ec-comparison">
     <div class="ec-label">Comparison</div>
     <div class="ec-body">
       <strong>Standard doorbell:</strong> 2-4kHz sudden onset, dog barks 95% of the time.
-      <strong>HushBell:</strong> 40Hz sub-hearing + 2kHz anti-startle fade, 99% no-bark probability.
+      <strong>HushBell:</strong> 40Hz sub-hearing + variable-frequency anti-startle fade + anti-conditioning randomisation.
     </div>
   </div>
 
   <!-- How It Works -->
-  <div class="explainer" id="explainerCard">
+  <div class="explainer">
     <h2>How It Works — In Plain Language</h2>
     <p>Standard doorbells trigger barking because dogs hear the sudden sound and react on instinct. HushBell replaces that with two carefully chosen signals that dogs cannot hear or react to.</p>
-    <p><span class="freq-tag">Channel 1: 40Hz tactile tone.</span> Dogs hear from 67Hz upwards. A 40Hz tone sits below their hearing floor entirely. You feel it as a low rumble through the speaker or furniture — the real hardware uses a tactile transducer bolted to a surface. The dog hears nothing.</p>
-    <p><span class="freq-tag amber">Channel 2: 2000Hz with 500ms fade-in.</span> The acoustic startle reflex in dogs triggers when a sound appears in under 20 milliseconds. By fading the 2000Hz tone in over 500 milliseconds — 25 times slower than the startle threshold — the sound registers as background ambient noise rather than an alarm. No bark.</p>
-    <p>Combined, the two channels give a 99% no-bark probability on the tactile channel alone. The spectrum analyser above proves both frequencies are present in real time.</p>
-    <p>Design by Thomas Frumkin. Implementation by CodeTonight. AI Craftspeople Guild.</p>
+    <p><span class="freq-tag">Channel 1: 40Hz tactile tone.</span> Dogs hear from 67Hz upwards. A 40Hz tone sits below their hearing floor entirely. You feel it as a low rumble through headphones — the real hardware uses a tactile transducer. The dog hears nothing.</p>
+    <p><span class="freq-tag amber">Channel 2: Variable frequency with fade-in.</span> The acoustic startle reflex triggers when sound appears in under 20ms. HushBell fades in over 500ms — 25x slower. The frequency varies between rings to prevent classical conditioning (dogs learning to associate a fixed tone with door activity).</p>
+    <p>Four frequency modes: <strong>Fixed</strong> (original 2kHz), <strong>Random</strong> (800-3500Hz), <strong>Preset</strong> (rotate through favourites), <strong>Vagal</strong> (800-1100Hz range that resonates with the human vagus nerve — pleasant to hear).</p>
+    <p>Design by Thomas Frumkin. Anti-conditioning fix by Alex. Implementation by CodeTonight. AI Craftspeople Guild.</p>
   </div>
 
 </main>
 
-<footer>HUSHBELL POC &nbsp;&middot;&nbsp; 40Hz BELOW 67Hz DOG HEARING FLOOR &nbsp;&middot;&nbsp; 2000Hz ANTI-STARTLE FADE &nbsp;&middot;&nbsp; ENTER KONSULT</footer>
+<footer>HUSHBELL POC &nbsp;&middot;&nbsp; 40Hz BELOW 67Hz DOG HEARING FLOOR &nbsp;&middot;&nbsp; ANTI-STARTLE FADE &nbsp;&middot;&nbsp; ANTI-CONDITIONING &nbsp;&middot;&nbsp; ENTER KONSULT</footer>
 
 <script>
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -384,12 +467,10 @@ function setTheme(id) {
   });
 }
 
-// Auto-detect from OS preference on first visit
 function initTheme() {
   const saved = localStorage.getItem(THEME_KEY);
   if (saved) { setTheme(saved); return; }
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  setTheme(prefersDark ? 'dark' : 'light');
+  setTheme(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
 }
 
 document.getElementById('themeSwitcher').addEventListener('click', e => {
@@ -397,7 +478,6 @@ document.getElementById('themeSwitcher').addEventListener('click', e => {
   if (btn && btn.dataset.theme) setTheme(btn.dataset.theme);
 });
 
-// Listen for OS theme changes
 window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
   if (!localStorage.getItem(THEME_KEY)) setTheme(e.matches ? 'dark' : 'light');
 });
@@ -405,7 +485,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e =
 initTheme();
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// AUDIO ENGINE
+// AUDIO ENGINE — Variable frequency with anti-conditioning
 // ═══════════════════════════════════════════════════════════════════════════════
 const MAX_RINGS = 1200;
 let ringsLeft = MAX_RINGS;
@@ -413,6 +493,10 @@ let audioCtx = null;
 let analyser = null;
 let rafId = null;
 let isRinging = false;
+let currentSecondaryFreq = 2000;
+let presetIndex = 0;
+const DEFAULT_PRESETS = [1000, 1500, 2000, 2500, 3000];
+let activePresets = [...DEFAULT_PRESETS];
 
 function initAudio() {
   if (audioCtx) return;
@@ -424,6 +508,61 @@ function initAudio() {
   drawFFT();
 }
 
+// ─── Frequency resolution (mirrors Python resolve_secondary_freq) ────────────
+function resolveFrequency() {
+  const mode = document.getElementById('freqMode').value;
+  switch (mode) {
+    case 'fixed': return 2000;
+    case 'random': {
+      const min = parseInt(document.getElementById('freqMin').value);
+      const max = parseInt(document.getElementById('freqMax').value);
+      return min + Math.random() * (max - min);
+    }
+    case 'preset': {
+      if (activePresets.length === 0) return 2000;
+      const freq = activePresets[presetIndex % activePresets.length];
+      presetIndex++;
+      return freq;
+    }
+    case 'vagal': {
+      const center = parseInt(document.getElementById('vagalCenter').value);
+      const spread = parseInt(document.getElementById('vagalSpread').value);
+      const u1 = Math.random(), u2 = Math.random();
+      const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+      return Math.max(500, Math.min(4000, center + z * spread));
+    }
+    default: return 2000;
+  }
+}
+
+// ─── Envelope (all types guarantee zero onset) ───────────────────────────────
+function applyEnvelope(gainNode, now, fadeInSec, peakGain) {
+  const envType = document.getElementById('envelopeType').value;
+  gainNode.gain.setValueAtTime(0, now);
+  switch (envType) {
+    case 'linear':
+      gainNode.gain.linearRampToValueAtTime(peakGain, now + fadeInSec);
+      break;
+    case 'sine': {
+      const steps = 20;
+      for (let i = 1; i <= steps; i++) {
+        const t = i / steps;
+        gainNode.gain.linearRampToValueAtTime(Math.sin(t * Math.PI / 2) * peakGain, now + t * fadeInSec);
+      }
+      break;
+    }
+    case 'exponential': {
+      const steps = 20;
+      for (let i = 1; i <= steps; i++) {
+        const t = i / steps;
+        gainNode.gain.linearRampToValueAtTime(((Math.exp(3 * t) - 1) / (Math.exp(3) - 1)) * peakGain, now + t * fadeInSec);
+      }
+      break;
+    }
+  }
+}
+
+// ─── Ring handler ─────────────────────────────────────────────────────────────
 function handleRing() {
   if (isRinging || ringsLeft <= 0) return;
   initAudio();
@@ -437,6 +576,7 @@ function handleRing() {
 
   const now = audioCtx.currentTime;
   const duration = 1.5;
+  const fadeInSec = 0.5;
 
   // 40Hz — flat, no fade (sub-threshold dog hearing)
   const osc40 = audioCtx.createOscillator();
@@ -449,30 +589,89 @@ function handleRing() {
   osc40.start(now);
   osc40.stop(now + duration);
 
-  // 2000Hz — 500ms linear fade-in (anti-startle)
-  const osc2k = audioCtx.createOscillator();
-  const gain2k = audioCtx.createGain();
-  osc2k.type = 'sine';
-  osc2k.frequency.value = 2000;
-  gain2k.gain.setValueAtTime(0, now);
-  gain2k.gain.linearRampToValueAtTime(0.4, now + 0.5);
-  gain2k.gain.setValueAtTime(0.4, now + duration - 0.1);
-  gain2k.gain.linearRampToValueAtTime(0, now + duration);
-  osc2k.connect(gain2k);
-  gain2k.connect(analyser);
-  osc2k.start(now);
-  osc2k.stop(now + duration);
+  // Secondary — variable frequency with anti-startle fade-in (ALWAYS applied)
+  currentSecondaryFreq = resolveFrequency();
+  const oscSec = audioCtx.createOscillator();
+  const gainSec = audioCtx.createGain();
+  oscSec.type = 'sine';
+  oscSec.frequency.value = currentSecondaryFreq;
+  applyEnvelope(gainSec, now, fadeInSec, 0.4);
+  gainSec.gain.setValueAtTime(0.4, now + duration - 0.1);
+  gainSec.gain.linearRampToValueAtTime(0, now + duration);
+  oscSec.connect(gainSec);
+  gainSec.connect(analyser);
+  oscSec.start(now);
+  oscSec.stop(now + duration);
 
-  setStatus('ACTIVE', 'FADING IN', '500ms', duration + 's');
+  // Pleasant mode: harmonic + vibrato
+  const isPleasant = document.getElementById('pleasantMode').value === 'on';
+  if (isPleasant) {
+    const harmonicFreq = currentSecondaryFreq * 1.25;
+    if (harmonicFreq <= 4000) {
+      const oscHarm = audioCtx.createOscillator();
+      const gainHarm = audioCtx.createGain();
+      oscHarm.type = 'sine';
+      oscHarm.frequency.value = harmonicFreq;
+      applyEnvelope(gainHarm, now, fadeInSec, 0.06);
+      gainHarm.gain.setValueAtTime(0.06, now + duration - 0.1);
+      gainHarm.gain.linearRampToValueAtTime(0, now + duration);
+      oscHarm.connect(gainHarm);
+      gainHarm.connect(analyser);
+      oscHarm.start(now);
+      oscHarm.stop(now + duration);
+    }
+    const vibratoLFO = audioCtx.createOscillator();
+    const vibratoGain = audioCtx.createGain();
+    vibratoLFO.type = 'sine';
+    vibratoLFO.frequency.value = 5;
+    vibratoGain.gain.value = currentSecondaryFreq * 0.02;
+    vibratoLFO.connect(vibratoGain);
+    vibratoGain.connect(oscSec.frequency);
+    vibratoLFO.start(now);
+    vibratoLFO.stop(now + duration);
+  }
+
+  const mode = document.getElementById('freqMode').value;
+  const envType = document.getElementById('envelopeType').value;
+  setStatus('ACTIVE', 'FADING IN', Math.round(currentSecondaryFreq) + 'Hz', envType + ' ' + fadeInSec + 's', duration + 's');
   animateLEDs(duration * 1000);
 
   setTimeout(() => {
     isRinging = false;
-    setStatus('IDLE', 'IDLE', '\u2014', '\u2014');
+    setStatus('IDLE', 'IDLE', '\u2014', '\u2014', '\u2014');
     evaluateEmergentRules();
   }, duration * 1000);
 
   evaluateEmergentRules();
+}
+
+// ─── Frequency mode UI switching ──────────────────────────────────────────────
+function onFreqModeChange() {
+  const mode = document.getElementById('freqMode').value;
+  document.getElementById('randomControls').className = 'sub-controls' + (mode === 'random' ? ' visible' : '');
+  document.getElementById('presetControls').className = 'sub-controls' + (mode === 'preset' ? ' visible' : '');
+  document.getElementById('vagalControls').className = 'sub-controls' + (mode === 'vagal' ? ' visible' : '');
+}
+
+function updateRangeLabel(inputId, labelId) {
+  const val = document.getElementById(inputId).value;
+  const el = document.getElementById(labelId);
+  el.textContent = labelId.includes('Spread') ? '+/- ' + val : val + ' Hz';
+}
+
+function initPresetChips() {
+  const container = document.getElementById('presetChips');
+  const allFreqs = [500, 800, 1000, 1200, 1500, 1800, 2000, 2500, 3000, 3500];
+  allFreqs.forEach(f => {
+    const chip = document.createElement('span');
+    chip.className = 'preset-chip' + (DEFAULT_PRESETS.includes(f) ? ' active' : '');
+    chip.textContent = f + 'Hz';
+    chip.onclick = () => {
+      chip.classList.toggle('active');
+      activePresets = allFreqs.filter((freq, i) => container.children[i].classList.contains('active'));
+    };
+    container.appendChild(chip);
+  });
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -503,7 +702,7 @@ function animateLEDs(totalMs) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// BATTERY
+// BATTERY + STATUS
 // ═══════════════════════════════════════════════════════════════════════════════
 function updateBattery() {
   const pct = ringsLeft / MAX_RINGS;
@@ -515,15 +714,16 @@ function updateBattery() {
   }
 }
 
-function setStatus(s40, s2k, fade, dur) {
+function setStatus(s40, s2k, freq, fade, dur) {
   document.getElementById('s40').textContent = s40;
   document.getElementById('s2k').textContent = s2k;
+  document.getElementById('sFreq').textContent = freq;
   document.getElementById('sFade').textContent = fade;
   document.getElementById('sDur').textContent = dur;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// FFT DRAW LOOP
+// FFT DRAW LOOP — Dynamic frequency marker
 // ═══════════════════════════════════════════════════════════════════════════════
 function drawFFT() {
   const canvas = document.getElementById('fft');
@@ -541,12 +741,12 @@ function drawFFT() {
     rafId = requestAnimationFrame(draw);
     analyser.getByteFrequencyData(data);
 
-    const theme = document.documentElement.getAttribute('data-theme');
-    const isDark = theme === 'dark';
     const bgColor = getComputedStyle(document.documentElement).getPropertyValue('--canvas-bg').trim();
     ctx.fillStyle = bgColor;
     ctx.fillRect(0, 0, W, H);
 
+    const theme = document.documentElement.getAttribute('data-theme');
+    const isDark = theme === 'dark';
     const gridFreqs = [40, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000];
     ctx.strokeStyle = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)';
     ctx.lineWidth = 1;
@@ -555,8 +755,10 @@ function drawFFT() {
       ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
     });
 
+    // Dynamic markers: 40Hz + current secondary frequency
     const accent = getComputedStyle(document.documentElement).getPropertyValue('--accent').trim();
-    [[40, accent], [2000, '#FFBF00']].forEach(([f, color]) => {
+    const secFreq = currentSecondaryFreq;
+    [[40, accent], [secFreq, '#FFBF00']].forEach(([f, color]) => {
       const x = Math.round(f / maxFreq * W);
       ctx.strokeStyle = color;
       ctx.lineWidth = 1;
@@ -573,7 +775,7 @@ function drawFFT() {
       const freq = i / bufLen * nyquist;
       let color;
       if (Math.abs(freq - 40) < 15) color = accent;
-      else if (Math.abs(freq - 2000) < 60) color = '#FFBF00';
+      else if (Math.abs(freq - secFreq) < 60) color = '#FFBF00';
       else color = barIdle;
       ctx.fillStyle = color;
       ctx.fillRect(i * barW, H - bh, Math.max(barW - 0.5, 1), bh);
@@ -583,7 +785,8 @@ function drawFFT() {
     ctx.fillStyle = accent;
     ctx.fillText('40Hz', Math.round(40 / maxFreq * W) + 3, 14);
     ctx.fillStyle = '#FFBF00';
-    ctx.fillText('2000Hz', Math.round(2000 / maxFreq * W) - 36, 14);
+    const xSec = Math.round(secFreq / maxFreq * W);
+    ctx.fillText(Math.round(secFreq) + 'Hz', Math.max(3, xSec - 20), 14);
   }
   draw();
 }
@@ -592,31 +795,23 @@ function drawFFT() {
 // EMERGENT UI ENGINE — Behaviour-driven card rendering
 // ═══════════════════════════════════════════════════════════════════════════════
 const behaviourCtx = {
-  ringCount: 0,
-  lastRingTime: 0,
-  visitStart: Date.now(),
+  ringCount: 0, lastRingTime: 0, visitStart: Date.now(),
   scrolledToSpectrum: false,
-  suggestionShown: false,
-  projectionShown: false,
-  educationShown: false,
-  comparisonShown: false,
+  suggestionShown: false, projectionShown: false, educationShown: false, comparisonShown: false,
 };
 
 function showCard(id) { document.getElementById(id).classList.add('visible'); }
 function hideCard(id) { document.getElementById(id).classList.remove('visible'); }
 
 const EMERGENT_RULES = [
-  // First visit, no rings after 3s: suggest trying it
   { id: 'ec-suggestion',
     condition: ctx => ctx.ringCount === 0 && !ctx.suggestionShown && (Date.now() - ctx.visitStart) > 3000,
     action: ctx => { showCard('ec-suggestion'); ctx.suggestionShown = true; }
   },
-  // Hide suggestion after first ring
   { id: 'ec-suggestion-hide',
     condition: ctx => ctx.ringCount > 0 && ctx.suggestionShown,
     action: () => hideCard('ec-suggestion')
   },
-  // After 3 rings: show battery projection
   { id: 'ec-projection',
     condition: ctx => ctx.ringCount >= 3 && !ctx.projectionShown,
     action: ctx => {
@@ -632,12 +827,10 @@ const EMERGENT_RULES = [
       ctx.projectionShown = true;
     }
   },
-  // Scrolled to spectrum: show education
   { id: 'ec-education',
     condition: ctx => ctx.scrolledToSpectrum && !ctx.educationShown && ctx.ringCount > 0,
     action: ctx => { showCard('ec-education'); ctx.educationShown = true; }
   },
-  // After 5 rings: show comparison
   { id: 'ec-comparison',
     condition: ctx => ctx.ringCount >= 5 && !ctx.comparisonShown,
     action: ctx => { showCard('ec-comparison'); ctx.comparisonShown = true; }
@@ -650,7 +843,6 @@ function evaluateEmergentRules() {
   });
 }
 
-// Scroll observer for spectrum card
 const spectrumObserver = new IntersectionObserver(entries => {
   entries.forEach(entry => {
     if (entry.isIntersecting) {
@@ -661,8 +853,10 @@ const spectrumObserver = new IntersectionObserver(entries => {
 }, { threshold: 0.5 });
 spectrumObserver.observe(document.getElementById('fft'));
 
-// Periodic evaluation (idle detection)
 setInterval(evaluateEmergentRules, 2000);
+
+// ─── Init ─────────────────────────────────────────────────────────────────────
+initPresetChips();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Adds a full "Design System — Swiss Nihilism (ENTER Konsult)" section documenting the visual language required for all AI-assisted contributions: 0px border-radius, no shadows, monospace label hierarchy (`'Courier New'`, uppercase, `letter-spacing: 0.08–0.12em`), system body font, orange accent tokens (`#ea580c` light/dark, `#996F00` neutral), CSS custom property inventory, theme table, emergent UI pattern table, and Web Audio signal-chain patterns.
- **docs/index.html**: Was the old v1 (fixed 2kHz only, no frequency controls). Synced to match `web/index.html` exactly — both files are now identical as required by the design system contract. The sync brings in all frequency modes (fixed/random/preset/vagal), envelope types, pleasant mode, variable-freq FFT, and the full emergent UI engine.

## Test plan

- [ ] Open both `web/index.html` and `docs/index.html` in a browser — they should look and behave identically
- [ ] Verify ring button produces audio with all four frequency modes
- [ ] Verify emergent cards appear at correct thresholds (suggestion at 3s idle, projection at 3 rings, education on spectrum scroll, comparison at 5 rings)
- [ ] Check CLAUDE.md renders correctly on GitHub — verify all tables and code blocks are valid Markdown
- [ ] Confirm no border-radius or box-shadow present in either HTML file

Closes #6

---
_Generated by [Claude Code](https://claude.ai/code/session_012Gg2ViYEDp8unxMjWEzAEK)_