### PR TITLE
feat: ULTRAWIN — class-based MQTT state machine + Ring Sigil

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -372,6 +372,21 @@
     font-family: 'Courier New', monospace; font-size: 13px;
     color: var(--accent); word-break: break-all;
   }
+
+  /* ─── RING SIGIL ──────────────────────────── */
+  /* Deterministic ASCII fingerprint per ring — same payload, same sigil, byte-for-byte. */
+  .sigil-stack { display: flex; flex-direction: column; }
+  .sigil { padding: 8px 0; border-bottom: 1px solid var(--border); }
+  .sigil:last-child { border-bottom: none; }
+  .sigil-art {
+    font-family: 'Courier New', monospace; font-size: 12px;
+    line-height: 1.05; color: var(--accent); white-space: pre; letter-spacing: 0.04em;
+  }
+  .sigil-cap {
+    font-family: 'Courier New', monospace; font-size: 11px;
+    text-transform: uppercase; letter-spacing: 0.08em;
+    color: var(--text-muted); margin-top: 4px;
+  }
 </style>
 </head>
 <body>
@@ -564,6 +579,12 @@
       <div class="stat">Fade-in &nbsp;<strong id="sFade">—</strong></div>
       <div class="stat">Duration &nbsp;<strong id="sDur">—</strong></div>
     </div>
+  </div>
+
+  <!-- Ring Sigil — deterministic fingerprint per ring -->
+  <div class="card">
+    <div class="card-label">Ring Sigil — Frequency Fingerprint</div>
+    <div class="sigil-stack" id="sigilStack"></div>
   </div>
 
   <!-- Emergent: Comparison -->
@@ -783,7 +804,7 @@ function handleRing() {
 
   evaluateEmergentRules();
 
-  if (mqtt && mqtt.connected) {
+  if (mqtt && mqtt.state === 'connected') {
     mqtt.publish('hushbell/ring', {
       source: 'web', ts: Date.now(),
       frequency: Math.round(currentSecondaryFreq),
@@ -791,6 +812,9 @@ function handleRing() {
       pleasant: document.getElementById('pleasantMode').value === 'on'
     });
   }
+
+  // Ring Sigil — deterministic ASCII fingerprint of THIS ring's tone (web origin).
+  renderSigil(currentSecondaryFreq, envType, isPleasant, false);
 }
 
 // ─── Frequency mode UI switching ──────────────────────────────────────────────
@@ -1098,6 +1122,48 @@ async function shareHushBell() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// RING SIGIL — deterministic ASCII fingerprint per ring
+// Same payload (freq | envelope | pleasant) => same sigil AND same hash8 id, byte-for-byte.
+// Visually-distinct sigils ARE the evidence that random/vagal mode varies the tone;
+// two identical 'fixed' rings produce the IDENTICAL sigil, exposing that fixed does not vary.
+// ═══════════════════════════════════════════════════════════════════════════════
+function ringHash(s) {
+  let h = 2166136261 >>> 0;            // FNV-1a 32-bit
+  for (const c of s) { h ^= c.charCodeAt(0); h = Math.imul(h, 16777619); }
+  return h >>> 0;
+}
+
+function ringSigil(freq, env, pleasant) {
+  const seed = freq + '|' + env + '|' + (pleasant ? 'p' : '-');
+  let h = ringHash(seed);
+  const G = [' ', '.', ':', '-', '=', '#'];   // 6-level glyph ramp
+  const rows = [];
+  for (let r = 0; r < 5; r++) {
+    let line = '';
+    for (let c = 0; c < 11; c++) {
+      line += G[h % G.length];
+      h = (Math.imul(h, 1103515245) + 12345) >>> 0;   // LCG walk over the FNV seed
+    }
+    rows.push(line);
+  }
+  return { art: rows.join('\n'), id: ('0000000' + ringHash(seed).toString(16)).slice(-8) };
+}
+
+function renderSigil(freq, env, pleasant, hw) {
+  const { art, id } = ringSigil(freq, env, pleasant);
+  const box = document.getElementById('sigilStack');
+  if (!box) return;
+  const el = document.createElement('div');
+  el.className = 'sigil';
+  el.innerHTML = '<pre class="sigil-art"></pre><div class="sigil-cap"></div>';
+  el.querySelector('.sigil-art').textContent = art;
+  el.querySelector('.sigil-cap').textContent =
+    (hw ? '[HW] ' : '') + Math.round(freq) + 'Hz / ' + env + ' / ' + id;
+  box.prepend(el);
+  while (box.children.length > 3) box.removeChild(box.lastChild);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // MQTT 3.1.1 CLIENT — Pure WebSocket, zero external dependencies
 // Implements: CONNECT, CONNACK, PUBLISH (QoS 0), SUBSCRIBE, SUBACK, PINGREQ/RESP
 // Broker: wss://broker.hivemq.com:8884/mqtt (HiveMQ free public) by default
@@ -1105,11 +1171,25 @@ async function shareHushBell() {
 class MQTTClient {
   constructor() {
     this.ws = null;
-    this.connected = false;
+    this.state = 'disconnected';
     this.clientId = 'hushbell-web-' + Math.random().toString(36).slice(2, 10);
     this.pingTimer = null;
     this.onMessage = null;
-    this.onDisconnect = null;
+    this.onStateChange = null;
+  }
+
+  // State transitions funnel through one place so the UI has a single source of truth.
+  _setState(s) { this.state = s; if (this.onStateChange) this.onStateChange(s); }
+
+  // Detach every handler BEFORE dropping the socket so a dead socket can never fire
+  // a zombie onmessage/onclose into live UI on a connect->error->reconnect cycle.
+  _cleanup() {
+    if (this.pingTimer) { clearInterval(this.pingTimer); this.pingTimer = null; }
+    if (this.ws) {
+      this.ws.onopen = this.ws.onmessage = this.ws.onclose = this.ws.onerror = null;
+      if (this.ws.readyState < 2) { try { this.ws.close(); } catch {} }
+      this.ws = null;
+    }
   }
 
   // MQTT variable-length remaining-length encoding
@@ -1169,6 +1249,8 @@ class MQTTClient {
 
   connect(url) {
     return new Promise((resolve, reject) => {
+      this._cleanup();              // idempotent re-entry guard — never leak a prior socket
+      this._setState('connecting');
       this.ws = new WebSocket(url, ['mqtt']);
       this.ws.binaryType = 'arraybuffer';
       const guard = setTimeout(() => reject(new Error('timeout')), 10000);
@@ -1178,7 +1260,7 @@ class MQTTClient {
         if (pkt.type === 'CONNACK') {
           clearTimeout(guard);
           if (pkt.code === 0) {
-            this.connected = true;
+            this._setState('connected');
             this.pingTimer = setInterval(() => {
               if (this.ws && this.ws.readyState === 1) this.ws.send(this._buildPingReq());
             }, 30000);
@@ -1188,94 +1270,87 @@ class MQTTClient {
           this.onMessage(pkt.topic, pkt.payload);
         }
       };
-      this.ws.onerror = () => { clearTimeout(guard); reject(new Error('WebSocket error')); };
-      this.ws.onclose = () => {
-        this.connected = false;
-        clearInterval(this.pingTimer);
-        if (this.onDisconnect) this.onDisconnect();
-      };
+      this.ws.onerror = () => { clearTimeout(guard); this._cleanup(); this._setState('error'); reject(new Error('WebSocket error')); };
+      this.ws.onclose = () => { this._cleanup(); this._setState('disconnected'); };
     });
   }
 
   publish(topic, payload) {
-    if (!this.connected || this.ws.readyState !== 1) return false;
+    if (this.state !== 'connected' || this.ws.readyState !== 1) return false;
     this.ws.send(this._buildPublish(topic,
       typeof payload === 'object' ? JSON.stringify(payload) : String(payload)));
     return true;
   }
 
   subscribe(topics) {
-    if (this.connected && this.ws.readyState === 1) this.ws.send(this._buildSubscribe(topics));
+    if (this.state === 'connected' && this.ws.readyState === 1) this.ws.send(this._buildSubscribe(topics));
   }
 
   disconnect() {
-    clearInterval(this.pingTimer);
-    if (this.ws) { this.ws.close(); this.ws = null; }
-    this.connected = false;
+    this._cleanup();
+    this._setState('disconnected');
   }
 }
 
 // ─── MQTT UI controller ────────────────────────────────────────────────────────
-let mqtt = null;
+// One persistent client. The single onStateChange handler is the ONLY place that
+// touches the indicator / button / feed — no duplicated disabled/textContent juggling.
+const mqtt = new MQTTClient();
 
-function mqttSetStatus(state, text) {
+mqtt.onStateChange = state => {
   const ind = document.getElementById('mqttIndicator');
   const btn = document.getElementById('mqttConnBtn');
-  ind.className = 'mqtt-indicator' + (state === 'live' ? ' live' : state === 'err' ? ' err' : '');
-  ind.textContent = text;
-  btn.textContent = state === 'live' ? 'Disconnect' : 'Connect';
-  btn.className   = 'mqtt-conn-btn'  + (state === 'live' ? ' live' : '');
-  document.getElementById('mqttFeed').style.display = state === 'live' ? '' : 'none';
+  const cls = state === 'connected' ? ' live' : state === 'error' ? ' err' : '';
+  ind.className = 'mqtt-indicator' + cls;
+  ind.textContent = {
+    connected: '● CONNECTED — ' + _mqttBrokerHost(),
+    connecting: '… CONNECTING',
+    error: '✕ ERROR — check broker URL',
+    disconnected: '○ DISCONNECTED',
+  }[state];
+  btn.textContent = state === 'connected' ? 'Disconnect' : 'Connect';
+  btn.className = 'mqtt-conn-btn' + (state === 'connected' ? ' live' : '');
+  btn.disabled = state === 'connecting';
+  document.getElementById('mqttFeed').style.display = state === 'connected' ? '' : 'none';
+};
+
+mqtt.onMessage = (topic, payload) => {
+  document.getElementById('mqttLastTopic').textContent = topic;
+  document.getElementById('mqttLastPayload').textContent = payload;
+  try {
+    const d = JSON.parse(payload);
+    if (topic === 'hushbell/status') {
+      document.getElementById('mqttHwStatus').textContent =
+        (d.state || '—').toUpperCase() + (d.frequency ? ' · ' + Math.round(d.frequency) + 'Hz' : '');
+      // ESP32 echoing a ring back renders its OWN [HW] sigil — round-trip integrity proof.
+      const hwFreq = d.frequency != null ? d.frequency : d.freq;
+      if (hwFreq != null) renderSigil(hwFreq, d.envelope || '-', !!d.pleasant, true);
+    }
+    if (topic === 'hushbell/battery') {
+      const pct = d.rings_left != null && d.capacity
+        ? Math.round(d.rings_left / d.capacity * 100) + '%' : '';
+      document.getElementById('mqttHwBattery').textContent =
+        (d.rings_left != null ? d.rings_left + ' rings' : '—') + (pct ? ' (' + pct + ')' : '');
+    }
+  } catch {}
+};
+
+function _mqttBrokerHost() {
+  const url = document.getElementById('mqttBrokerUrl').value.trim();
+  try { return new URL(url).host; } catch { return url; }
 }
 
 async function mqttToggle() {
-  if (mqtt && mqtt.connected) {
-    mqtt.disconnect(); mqtt = null;
-    mqttSetStatus('off', '○ DISCONNECTED');
+  if (mqtt.state === 'connected' || mqtt.state === 'connecting') {
+    mqtt.disconnect();
     return;
   }
   const url = document.getElementById('mqttBrokerUrl').value.trim();
   if (!url) return;
-  mqttSetStatus('off', '… CONNECTING');
-  document.getElementById('mqttConnBtn').disabled = true;
-
-  mqtt = new MQTTClient();
-
-  mqtt.onDisconnect = () => {
-    mqttSetStatus('off', '○ DISCONNECTED');
-    document.getElementById('mqttConnBtn').disabled = false;
-  };
-
-  mqtt.onMessage = (topic, payload) => {
-    document.getElementById('mqttLastTopic').textContent = topic;
-    document.getElementById('mqttLastPayload').textContent = payload;
-    try {
-      const d = JSON.parse(payload);
-      if (topic === 'hushbell/status') {
-        document.getElementById('mqttHwStatus').textContent =
-          (d.state || '—').toUpperCase() + (d.frequency ? ' · ' + Math.round(d.frequency) + 'Hz' : '');
-      }
-      if (topic === 'hushbell/battery') {
-        const pct = d.rings_left != null && d.capacity
-          ? Math.round(d.rings_left / d.capacity * 100) + '%' : '';
-        document.getElementById('mqttHwBattery').textContent =
-          (d.rings_left != null ? d.rings_left + ' rings' : '—') + (pct ? ' (' + pct + ')' : '');
-      }
-    } catch {}
-  };
-
   try {
     await mqtt.connect(url);
     mqtt.subscribe(['hushbell/status', 'hushbell/battery', 'hushbell/config/state']);
-    let host;
-    try { host = new URL(url).host; } catch { host = url; }
-    mqttSetStatus('live', '● CONNECTED — ' + host);
-    document.getElementById('mqttConnBtn').disabled = false;
-  } catch (err) {
-    mqttSetStatus('err', '✕ ERROR: ' + err.message);
-    document.getElementById('mqttConnBtn').disabled = false;
-    mqtt = null;
-  }
+  } catch { /* onStateChange('error') already drove the UI */ }
 }
 
 // ─── Init ─────────────────────────────────────────────────────────────────────

--- a/docs/index.html
+++ b/docs/index.html
@@ -814,7 +814,10 @@ function handleRing() {
   }
 
   // Ring Sigil — deterministic ASCII fingerprint of THIS ring's tone (web origin).
-  renderSigil(currentSecondaryFreq, envType, isPleasant, false);
+  // Seed from the SAME rounded freq that was published to MQTT (line above), so the
+  // web sigil and the hardware-echo sigil (rendered from the int the ESP32 received)
+  // are byte-identical on an honest round-trip — the feature's whole point.
+  renderSigil(Math.round(currentSecondaryFreq), envType, isPleasant, false);
 }
 
 // ─── Frequency mode UI switching ──────────────────────────────────────────────

--- a/tests/test_ring_sigil.py
+++ b/tests/test_ring_sigil.py
@@ -99,5 +99,31 @@ def test_sigil_card_and_stack_present(html):
 
 def test_sigil_wired_to_ring_and_hw_echo(html):
     # Web-origin ring renders a sigil; the ESP32 echo renders its own [HW]-tagged sigil.
-    assert "renderSigil(currentSecondaryFreq" in html
+    # The web-origin sigil seeds from the SAME rounded freq that is published to MQTT.
+    assert "renderSigil(Math.round(currentSecondaryFreq)" in html
     assert "[HW] " in html
+
+
+def test_web_sigil_provenance_matches_published_freq(html):
+    """AGORA blocker fix: the web-origin sigil MUST seed from the same rounded freq
+    that is published to hushbell/ring, or the sigil/HW-echo provenance breaks in
+    random+vagal modes (verified bug: float 2137.68 vs int 2138 -> different sigils on
+    an honest round-trip, falsely signalling a hardware mismatch). Goodhart anchor:
+    fails if the publish stops rounding OR the web sigil reverts to the bare float.
+    """
+    assert "frequency: Math.round(currentSecondaryFreq)" in html
+    assert "renderSigil(Math.round(currentSecondaryFreq)" in html
+    assert "renderSigil(currentSecondaryFreq," not in html
+
+
+def test_rounded_roundtrip_provenance_holds():
+    """With the fix the web side rounds before seeding the sigil, so it matches the
+    integer freq the ESP32 receives and echoes. The rounding is load-bearing: the raw
+    float seeds a different sigil (the bug being closed)."""
+    for f in (2137.68, 1847.31, 903.4):
+        r = round(f)
+        web = ring_sigil(r, "linear", False)["id"]       # fixed: web rounds
+        hw = ring_sigil(r, "linear", False)["id"]          # HW receives the int and echoes it
+        assert web == hw, f"provenance broken at {f}"
+        float_seed = ring_sigil(f, "linear", False)["id"]  # the OLD buggy web path
+        assert float_seed != web, f"rounding is a no-op at {f} — fix not load-bearing"

--- a/tests/test_ring_sigil.py
+++ b/tests/test_ring_sigil.py
@@ -1,0 +1,103 @@
+"""Ring Sigil — determinism + frequency-sensitivity + presence in both surfaces.
+
+The sigil is a pure function of (freq, envelope, pleasant). This test ports the
+FNV-1a + LCG glyph walk to Python and asserts the Goodhart anchor:
+  same payload  -> identical id   (reproducible)
+  different freq -> different id   (it genuinely depends on the frequency)
+A revert that makes the sigil ignore frequency (e.g. a random flourish) fails here.
+
+Static-HTML assertions also confirm the JS functions + card markup are present and
+identical across docs/ and web/ (zero-CDN, no browser).
+"""
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HTML_FILES = [REPO_ROOT / "docs" / "index.html", REPO_ROOT / "web" / "index.html"]
+
+U32 = 0xFFFFFFFF
+
+
+def _imul(a, b):
+    """JS Math.imul: 32-bit signed multiply, returned as an unsigned 32-bit int."""
+    return (a * b) & U32
+
+
+def ring_hash(s: str) -> int:
+    """Python port of the JS FNV-1a 32-bit hash."""
+    h = 2166136261
+    for ch in s:
+        h ^= ord(ch)
+        h = _imul(h, 16777619)
+    return h & U32
+
+
+def ring_sigil(freq, env: str, pleasant: bool):
+    """Python port of ringSigil — must match the JS byte-for-byte by construction."""
+    seed = f"{freq}|{env}|{'p' if pleasant else '-'}"
+    h = ring_hash(seed)
+    glyphs = [" ", ".", ":", "-", "=", "#"]
+    rows = []
+    for _ in range(5):
+        line = ""
+        for _ in range(11):
+            line += glyphs[h % len(glyphs)]
+            h = (_imul(h, 1103515245) + 12345) & U32
+        rows.append(line)
+    return {"art": "\n".join(rows), "id": format(ring_hash(seed), "08x")[-8:]}
+
+
+# ─── Goodhart anchor: the pure function genuinely depends on its inputs ──────────
+
+def test_sigil_is_deterministic():
+    assert ring_sigil(2000, "linear", False)["id"] == ring_sigil(2000, "linear", False)["id"]
+
+
+def test_sigil_is_frequency_sensitive():
+    assert ring_sigil(2000, "linear", False)["id"] != ring_sigil(2100, "linear", False)["id"]
+
+
+def test_sigil_is_envelope_sensitive():
+    assert ring_sigil(2000, "linear", False)["id"] != ring_sigil(2000, "sine", False)["id"]
+
+
+def test_sigil_is_pleasant_sensitive():
+    assert ring_sigil(2000, "linear", False)["id"] != ring_sigil(2000, "linear", True)["id"]
+
+
+def test_sigil_shape_is_5_by_11():
+    art = ring_sigil(1234, "exponential", False)["art"]
+    lines = art.split("\n")
+    assert len(lines) == 5
+    assert all(len(line) == 11 for line in lines)
+
+
+def test_sigil_id_is_8_hex_chars():
+    sid = ring_sigil(900, "linear", True)["id"]
+    assert len(sid) == 8
+    assert all(c in "0123456789abcdef" for c in sid)
+
+
+# ─── Presence in the rendered HTML (both surfaces) ──────────────────────────────
+
+@pytest.fixture(params=HTML_FILES, ids=lambda p: p.parent.name)
+def html(request):
+    return request.param.read_text(encoding="utf-8")
+
+
+def test_sigil_functions_present(html):
+    assert "function ringHash(" in html
+    assert "function ringSigil(" in html
+    assert "function renderSigil(" in html
+
+
+def test_sigil_card_and_stack_present(html):
+    assert 'id="sigilStack"' in html
+    assert "Ring Sigil" in html
+
+
+def test_sigil_wired_to_ring_and_hw_echo(html):
+    # Web-origin ring renders a sigil; the ESP32 echo renders its own [HW]-tagged sigil.
+    assert "renderSigil(currentSecondaryFreq" in html
+    assert "[HW] " in html

--- a/tests/test_web_mqtt_state.py
+++ b/tests/test_web_mqtt_state.py
@@ -1,0 +1,61 @@
+"""Static-HTML assertions for the MQTT state-machine upgrade (no browser needed).
+
+Goodhart-resistant: each test fails if someone reverts the explicit state machine
+back to a boolean `this.connected` flag, or drops the handler-nulling in `_cleanup`.
+Both docs/index.html and web/index.html are checked — they must stay byte-identical,
+so a regression on either surface is caught.
+"""
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HTML_FILES = [REPO_ROOT / "docs" / "index.html", REPO_ROOT / "web" / "index.html"]
+
+
+@pytest.fixture(params=HTML_FILES, ids=lambda p: p.parent.name)
+def html(request):
+    return request.param.read_text(encoding="utf-8")
+
+
+def test_no_boolean_connected_flag(html):
+    # The ad-hoc boolean flag is gone — state is a string machine instead.
+    assert "this.connected =" not in html
+    assert "mqtt.connected" not in html
+
+
+def test_state_machine_present(html):
+    assert "_setState(" in html
+    assert "this.state = 'disconnected'" in html
+    # Every documented state must be reachable in the code.
+    for state in ("connecting", "connected", "error", "disconnected"):
+        assert f"'{state}'" in html
+
+
+def test_single_state_change_callback(html):
+    # One onStateChange callback replaces the old onDisconnect + mqttSetStatus juggling.
+    assert "onStateChange" in html
+    assert "onDisconnect" not in html
+    assert "function mqttSetStatus" not in html
+
+
+def test_cleanup_nulls_all_four_ws_handlers(html):
+    # The hardened cleanup must detach onopen/onmessage/onclose/onerror before
+    # dropping the socket — proof the zombie-callback class is closed.
+    assert "this.ws.onopen = this.ws.onmessage = this.ws.onclose = this.ws.onerror = null" in html
+    assert "_cleanup()" in html
+
+
+def test_publish_and_subscribe_guard_on_state(html):
+    # Guards key off the state machine, not the removed boolean.
+    assert "this.state !== 'connected'" in html
+    assert "this.state === 'connected'" in html
+
+
+def test_working_ui_ids_preserved(html):
+    # Main's richer feed UI ids must survive the graft unchanged.
+    for el_id in (
+        "mqttFeed", "mqttConnBtn", "mqttIndicator",
+        "mqttHwStatus", "mqttHwBattery", "mqttLastTopic", "mqttLastPayload",
+    ):
+        assert f'id="{el_id}"' in html

--- a/web/index.html
+++ b/web/index.html
@@ -372,6 +372,21 @@
     font-family: 'Courier New', monospace; font-size: 13px;
     color: var(--accent); word-break: break-all;
   }
+
+  /* ─── RING SIGIL ──────────────────────────── */
+  /* Deterministic ASCII fingerprint per ring — same payload, same sigil, byte-for-byte. */
+  .sigil-stack { display: flex; flex-direction: column; }
+  .sigil { padding: 8px 0; border-bottom: 1px solid var(--border); }
+  .sigil:last-child { border-bottom: none; }
+  .sigil-art {
+    font-family: 'Courier New', monospace; font-size: 12px;
+    line-height: 1.05; color: var(--accent); white-space: pre; letter-spacing: 0.04em;
+  }
+  .sigil-cap {
+    font-family: 'Courier New', monospace; font-size: 11px;
+    text-transform: uppercase; letter-spacing: 0.08em;
+    color: var(--text-muted); margin-top: 4px;
+  }
 </style>
 </head>
 <body>
@@ -564,6 +579,12 @@
       <div class="stat">Fade-in &nbsp;<strong id="sFade">—</strong></div>
       <div class="stat">Duration &nbsp;<strong id="sDur">—</strong></div>
     </div>
+  </div>
+
+  <!-- Ring Sigil — deterministic fingerprint per ring -->
+  <div class="card">
+    <div class="card-label">Ring Sigil — Frequency Fingerprint</div>
+    <div class="sigil-stack" id="sigilStack"></div>
   </div>
 
   <!-- Emergent: Comparison -->
@@ -783,7 +804,7 @@ function handleRing() {
 
   evaluateEmergentRules();
 
-  if (mqtt && mqtt.connected) {
+  if (mqtt && mqtt.state === 'connected') {
     mqtt.publish('hushbell/ring', {
       source: 'web', ts: Date.now(),
       frequency: Math.round(currentSecondaryFreq),
@@ -791,6 +812,9 @@ function handleRing() {
       pleasant: document.getElementById('pleasantMode').value === 'on'
     });
   }
+
+  // Ring Sigil — deterministic ASCII fingerprint of THIS ring's tone (web origin).
+  renderSigil(currentSecondaryFreq, envType, isPleasant, false);
 }
 
 // ─── Frequency mode UI switching ──────────────────────────────────────────────
@@ -1098,6 +1122,48 @@ async function shareHushBell() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// RING SIGIL — deterministic ASCII fingerprint per ring
+// Same payload (freq | envelope | pleasant) => same sigil AND same hash8 id, byte-for-byte.
+// Visually-distinct sigils ARE the evidence that random/vagal mode varies the tone;
+// two identical 'fixed' rings produce the IDENTICAL sigil, exposing that fixed does not vary.
+// ═══════════════════════════════════════════════════════════════════════════════
+function ringHash(s) {
+  let h = 2166136261 >>> 0;            // FNV-1a 32-bit
+  for (const c of s) { h ^= c.charCodeAt(0); h = Math.imul(h, 16777619); }
+  return h >>> 0;
+}
+
+function ringSigil(freq, env, pleasant) {
+  const seed = freq + '|' + env + '|' + (pleasant ? 'p' : '-');
+  let h = ringHash(seed);
+  const G = [' ', '.', ':', '-', '=', '#'];   // 6-level glyph ramp
+  const rows = [];
+  for (let r = 0; r < 5; r++) {
+    let line = '';
+    for (let c = 0; c < 11; c++) {
+      line += G[h % G.length];
+      h = (Math.imul(h, 1103515245) + 12345) >>> 0;   // LCG walk over the FNV seed
+    }
+    rows.push(line);
+  }
+  return { art: rows.join('\n'), id: ('0000000' + ringHash(seed).toString(16)).slice(-8) };
+}
+
+function renderSigil(freq, env, pleasant, hw) {
+  const { art, id } = ringSigil(freq, env, pleasant);
+  const box = document.getElementById('sigilStack');
+  if (!box) return;
+  const el = document.createElement('div');
+  el.className = 'sigil';
+  el.innerHTML = '<pre class="sigil-art"></pre><div class="sigil-cap"></div>';
+  el.querySelector('.sigil-art').textContent = art;
+  el.querySelector('.sigil-cap').textContent =
+    (hw ? '[HW] ' : '') + Math.round(freq) + 'Hz / ' + env + ' / ' + id;
+  box.prepend(el);
+  while (box.children.length > 3) box.removeChild(box.lastChild);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // MQTT 3.1.1 CLIENT — Pure WebSocket, zero external dependencies
 // Implements: CONNECT, CONNACK, PUBLISH (QoS 0), SUBSCRIBE, SUBACK, PINGREQ/RESP
 // Broker: wss://broker.hivemq.com:8884/mqtt (HiveMQ free public) by default
@@ -1105,11 +1171,25 @@ async function shareHushBell() {
 class MQTTClient {
   constructor() {
     this.ws = null;
-    this.connected = false;
+    this.state = 'disconnected';
     this.clientId = 'hushbell-web-' + Math.random().toString(36).slice(2, 10);
     this.pingTimer = null;
     this.onMessage = null;
-    this.onDisconnect = null;
+    this.onStateChange = null;
+  }
+
+  // State transitions funnel through one place so the UI has a single source of truth.
+  _setState(s) { this.state = s; if (this.onStateChange) this.onStateChange(s); }
+
+  // Detach every handler BEFORE dropping the socket so a dead socket can never fire
+  // a zombie onmessage/onclose into live UI on a connect->error->reconnect cycle.
+  _cleanup() {
+    if (this.pingTimer) { clearInterval(this.pingTimer); this.pingTimer = null; }
+    if (this.ws) {
+      this.ws.onopen = this.ws.onmessage = this.ws.onclose = this.ws.onerror = null;
+      if (this.ws.readyState < 2) { try { this.ws.close(); } catch {} }
+      this.ws = null;
+    }
   }
 
   // MQTT variable-length remaining-length encoding
@@ -1169,6 +1249,8 @@ class MQTTClient {
 
   connect(url) {
     return new Promise((resolve, reject) => {
+      this._cleanup();              // idempotent re-entry guard — never leak a prior socket
+      this._setState('connecting');
       this.ws = new WebSocket(url, ['mqtt']);
       this.ws.binaryType = 'arraybuffer';
       const guard = setTimeout(() => reject(new Error('timeout')), 10000);
@@ -1178,7 +1260,7 @@ class MQTTClient {
         if (pkt.type === 'CONNACK') {
           clearTimeout(guard);
           if (pkt.code === 0) {
-            this.connected = true;
+            this._setState('connected');
             this.pingTimer = setInterval(() => {
               if (this.ws && this.ws.readyState === 1) this.ws.send(this._buildPingReq());
             }, 30000);
@@ -1188,94 +1270,87 @@ class MQTTClient {
           this.onMessage(pkt.topic, pkt.payload);
         }
       };
-      this.ws.onerror = () => { clearTimeout(guard); reject(new Error('WebSocket error')); };
-      this.ws.onclose = () => {
-        this.connected = false;
-        clearInterval(this.pingTimer);
-        if (this.onDisconnect) this.onDisconnect();
-      };
+      this.ws.onerror = () => { clearTimeout(guard); this._cleanup(); this._setState('error'); reject(new Error('WebSocket error')); };
+      this.ws.onclose = () => { this._cleanup(); this._setState('disconnected'); };
     });
   }
 
   publish(topic, payload) {
-    if (!this.connected || this.ws.readyState !== 1) return false;
+    if (this.state !== 'connected' || this.ws.readyState !== 1) return false;
     this.ws.send(this._buildPublish(topic,
       typeof payload === 'object' ? JSON.stringify(payload) : String(payload)));
     return true;
   }
 
   subscribe(topics) {
-    if (this.connected && this.ws.readyState === 1) this.ws.send(this._buildSubscribe(topics));
+    if (this.state === 'connected' && this.ws.readyState === 1) this.ws.send(this._buildSubscribe(topics));
   }
 
   disconnect() {
-    clearInterval(this.pingTimer);
-    if (this.ws) { this.ws.close(); this.ws = null; }
-    this.connected = false;
+    this._cleanup();
+    this._setState('disconnected');
   }
 }
 
 // ─── MQTT UI controller ────────────────────────────────────────────────────────
-let mqtt = null;
+// One persistent client. The single onStateChange handler is the ONLY place that
+// touches the indicator / button / feed — no duplicated disabled/textContent juggling.
+const mqtt = new MQTTClient();
 
-function mqttSetStatus(state, text) {
+mqtt.onStateChange = state => {
   const ind = document.getElementById('mqttIndicator');
   const btn = document.getElementById('mqttConnBtn');
-  ind.className = 'mqtt-indicator' + (state === 'live' ? ' live' : state === 'err' ? ' err' : '');
-  ind.textContent = text;
-  btn.textContent = state === 'live' ? 'Disconnect' : 'Connect';
-  btn.className   = 'mqtt-conn-btn'  + (state === 'live' ? ' live' : '');
-  document.getElementById('mqttFeed').style.display = state === 'live' ? '' : 'none';
+  const cls = state === 'connected' ? ' live' : state === 'error' ? ' err' : '';
+  ind.className = 'mqtt-indicator' + cls;
+  ind.textContent = {
+    connected: '● CONNECTED — ' + _mqttBrokerHost(),
+    connecting: '… CONNECTING',
+    error: '✕ ERROR — check broker URL',
+    disconnected: '○ DISCONNECTED',
+  }[state];
+  btn.textContent = state === 'connected' ? 'Disconnect' : 'Connect';
+  btn.className = 'mqtt-conn-btn' + (state === 'connected' ? ' live' : '');
+  btn.disabled = state === 'connecting';
+  document.getElementById('mqttFeed').style.display = state === 'connected' ? '' : 'none';
+};
+
+mqtt.onMessage = (topic, payload) => {
+  document.getElementById('mqttLastTopic').textContent = topic;
+  document.getElementById('mqttLastPayload').textContent = payload;
+  try {
+    const d = JSON.parse(payload);
+    if (topic === 'hushbell/status') {
+      document.getElementById('mqttHwStatus').textContent =
+        (d.state || '—').toUpperCase() + (d.frequency ? ' · ' + Math.round(d.frequency) + 'Hz' : '');
+      // ESP32 echoing a ring back renders its OWN [HW] sigil — round-trip integrity proof.
+      const hwFreq = d.frequency != null ? d.frequency : d.freq;
+      if (hwFreq != null) renderSigil(hwFreq, d.envelope || '-', !!d.pleasant, true);
+    }
+    if (topic === 'hushbell/battery') {
+      const pct = d.rings_left != null && d.capacity
+        ? Math.round(d.rings_left / d.capacity * 100) + '%' : '';
+      document.getElementById('mqttHwBattery').textContent =
+        (d.rings_left != null ? d.rings_left + ' rings' : '—') + (pct ? ' (' + pct + ')' : '');
+    }
+  } catch {}
+};
+
+function _mqttBrokerHost() {
+  const url = document.getElementById('mqttBrokerUrl').value.trim();
+  try { return new URL(url).host; } catch { return url; }
 }
 
 async function mqttToggle() {
-  if (mqtt && mqtt.connected) {
-    mqtt.disconnect(); mqtt = null;
-    mqttSetStatus('off', '○ DISCONNECTED');
+  if (mqtt.state === 'connected' || mqtt.state === 'connecting') {
+    mqtt.disconnect();
     return;
   }
   const url = document.getElementById('mqttBrokerUrl').value.trim();
   if (!url) return;
-  mqttSetStatus('off', '… CONNECTING');
-  document.getElementById('mqttConnBtn').disabled = true;
-
-  mqtt = new MQTTClient();
-
-  mqtt.onDisconnect = () => {
-    mqttSetStatus('off', '○ DISCONNECTED');
-    document.getElementById('mqttConnBtn').disabled = false;
-  };
-
-  mqtt.onMessage = (topic, payload) => {
-    document.getElementById('mqttLastTopic').textContent = topic;
-    document.getElementById('mqttLastPayload').textContent = payload;
-    try {
-      const d = JSON.parse(payload);
-      if (topic === 'hushbell/status') {
-        document.getElementById('mqttHwStatus').textContent =
-          (d.state || '—').toUpperCase() + (d.frequency ? ' · ' + Math.round(d.frequency) + 'Hz' : '');
-      }
-      if (topic === 'hushbell/battery') {
-        const pct = d.rings_left != null && d.capacity
-          ? Math.round(d.rings_left / d.capacity * 100) + '%' : '';
-        document.getElementById('mqttHwBattery').textContent =
-          (d.rings_left != null ? d.rings_left + ' rings' : '—') + (pct ? ' (' + pct + ')' : '');
-      }
-    } catch {}
-  };
-
   try {
     await mqtt.connect(url);
     mqtt.subscribe(['hushbell/status', 'hushbell/battery', 'hushbell/config/state']);
-    let host;
-    try { host = new URL(url).host; } catch { host = url; }
-    mqttSetStatus('live', '● CONNECTED — ' + host);
-    document.getElementById('mqttConnBtn').disabled = false;
-  } catch (err) {
-    mqttSetStatus('err', '✕ ERROR: ' + err.message);
-    document.getElementById('mqttConnBtn').disabled = false;
-    mqtt = null;
-  }
+  } catch { /* onStateChange('error') already drove the UI */ }
 }
 
 // ─── Init ─────────────────────────────────────────────────────────────────────

--- a/web/index.html
+++ b/web/index.html
@@ -814,7 +814,10 @@ function handleRing() {
   }
 
   // Ring Sigil — deterministic ASCII fingerprint of THIS ring's tone (web origin).
-  renderSigil(currentSecondaryFreq, envType, isPleasant, false);
+  // Seed from the SAME rounded freq that was published to MQTT (line above), so the
+  // web sigil and the hardware-echo sigil (rendered from the int the ESP32 received)
+  // are byte-identical on an honest round-trip — the feature's whole point.
+  renderSigil(Math.round(currentSecondaryFreq), envType, isPleasant, false);
 }
 
 // ─── Frequency mode UI switching ──────────────────────────────────────────────


### PR DESCRIPTION
## What this does (plain English)

The browser demo's MQTT client tracked its connection with a single true/false flag (`this.connected`) and poked the UI from several scattered places. Two real problems followed:

1. **Zombie callbacks.** `disconnect()` closed the socket but left its four event handlers attached. A connect → error → reconnect cycle could then fire a stale `onmessage`/`onclose` from the *dead* socket into the *live* UI.
2. **No single source of truth for status.** Connection state was juggled across `mqttSetStatus()`, an `onDisconnect` callback, and inline `mqtt.connected` checks — easy to drift out of sync.

This grafts the genuinely-better engineering from the `impl/hardware-ready` branch onto `main`:

- An explicit **four-state machine** — `disconnected / connecting / connected / error` — funnelled through one `_setState()`, replacing the boolean.
- A hardened **`_cleanup()`** that detaches **all four** WebSocket handlers (`onopen`/`onmessage`/`onclose`/`onerror`) *before* dropping the socket, and is also called as an idempotent re-entry guard at the start of `connect()`. The zombie-callback class is closed by construction.
- A **single `onStateChange` handler** that is now the only place touching the indicator, button, and feed. Lower cyclomatic complexity, one source of truth.

**Kept intact (no regression):** main's working UI element ids (`mqtt-row`, `mqttConnBtn`, `mqttFeed`, `mqttHwStatus`, `mqttHwBattery`, `mqttLastTopic`, `mqttLastPayload`) and main's richer four-row hardware feed parser (state + freq + rings + pct — more detailed than hardware-ready's collapsed online/offline).

### Delight: Ring Sigil

A small deterministic ASCII fingerprint rendered on every ring, computed purely from that ring's **frequency + envelope + pleasant flag** via a tiny FNV-1a hash + LCG glyph walk. Same tone → same sigil, byte-for-byte; printed `hash8` id is the same function of the input as the visual.

It is the opposite of decorative: visually-distinct sigils are the visible, falsifiable proof that random/vagal mode genuinely varies the tone — two consecutive *fixed* rings produce the *identical* sigil, instantly exposing that fixed mode does not vary. When a real ESP32 echoes a ring back on `hushbell/status`, its payload renders its own `[HW]`-tagged sigil — matching sigils side by side prove the hardware played exactly the frequency the browser sent (provenance-as-delight, mismatches are a bug you can see).

`docs/index.html` and `web/index.html` stay **byte-identical** (`diff` is empty). Vanilla JS, zero dependencies/CDN. Swiss Nihilism styling — no border-radius, no box-shadow, monospace, orange accent.

## Test plan

- [x] `tests/test_web_mqtt_state.py` — asserts the boolean flag is gone, the state machine + `onStateChange` exist, `_cleanup` nulls all four handlers, guards key off state, and the working UI ids survive. Runs on **both** `docs/` and `web/`.
- [x] `tests/test_ring_sigil.py` — ports the pure hash to Python and asserts determinism + frequency/envelope/pleasant sensitivity (Goodhart anchor: a freq-blind sigil fails the freq-sensitivity test — verified by mutation probe), plus presence + wiring in both surfaces.
- [x] `node --check` on the extracted script body passes; sigil determinism + frequency-sensitivity confirmed live in node.
- [x] `diff docs/index.html web/index.html` is empty.
- [x] 24/24 new tests pass.

Static string assertions only — no browser needed, matching the repo's zero-CDN constraint.