### PR TITLE
feat: keyboard shortcut (Space/Enter) to ring HushBell (#21)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -373,6 +373,13 @@
     color: var(--accent); word-break: break-all;
   }
 
+  /* ─── KEYBOARD HINT ──────────────────────── */
+  .kbd-hint {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--text-muted); text-align: center; margin-top: 6px;
+  }
+
   /* ─── RING SIGIL ──────────────────────────── */
   /* Deterministic ASCII fingerprint per ring — same payload, same sigil, byte-for-byte. */
   .sigil-stack { display: flex; flex-direction: column; }
@@ -532,6 +539,7 @@
 
   <!-- Ring Button -->
   <button class="ring-btn" id="ringBtn" onclick="handleRing()">&#x25B6; Ring HushBell</button>
+  <div class="kbd-hint">[Space / Enter]</div>
 
   <!-- Emergent: Battery Projection -->
   <div class="emergent-card projection" id="ec-projection">
@@ -1355,6 +1363,15 @@ async function mqttToggle() {
     mqtt.subscribe(['hushbell/status', 'hushbell/battery', 'hushbell/config/state']);
   } catch { /* onStateChange('error') already drove the UI */ }
 }
+
+// ─── Keyboard shortcut: Space / Enter triggers ring ──────────────────────────
+document.addEventListener('keydown', e => {
+  if (e.code !== 'Space' && e.code !== 'Enter') return;
+  const tag = document.activeElement && document.activeElement.tagName;
+  if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA' || tag === 'BUTTON') return;
+  e.preventDefault();
+  handleRing();
+});
 
 // ─── Init ─────────────────────────────────────────────────────────────────────
 initPresetChips();

--- a/web/index.html
+++ b/web/index.html
@@ -373,6 +373,13 @@
     color: var(--accent); word-break: break-all;
   }
 
+  /* ─── KEYBOARD HINT ──────────────────────── */
+  .kbd-hint {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--text-muted); text-align: center; margin-top: 6px;
+  }
+
   /* ─── RING SIGIL ──────────────────────────── */
   /* Deterministic ASCII fingerprint per ring — same payload, same sigil, byte-for-byte. */
   .sigil-stack { display: flex; flex-direction: column; }
@@ -532,6 +539,7 @@
 
   <!-- Ring Button -->
   <button class="ring-btn" id="ringBtn" onclick="handleRing()">&#x25B6; Ring HushBell</button>
+  <div class="kbd-hint">[Space / Enter]</div>
 
   <!-- Emergent: Battery Projection -->
   <div class="emergent-card projection" id="ec-projection">
@@ -1355,6 +1363,15 @@ async function mqttToggle() {
     mqtt.subscribe(['hushbell/status', 'hushbell/battery', 'hushbell/config/state']);
   } catch { /* onStateChange('error') already drove the UI */ }
 }
+
+// ─── Keyboard shortcut: Space / Enter triggers ring ──────────────────────────
+document.addEventListener('keydown', e => {
+  if (e.code !== 'Space' && e.code !== 'Enter') return;
+  const tag = document.activeElement && document.activeElement.tagName;
+  if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA' || tag === 'BUTTON') return;
+  e.preventDefault();
+  handleRing();
+});
 
 // ─── Init ─────────────────────────────────────────────────────────────────────
 initPresetChips();


### PR DESCRIPTION
## Summary

- Space and Enter trigger `handleRing()` when no interactive control is focused
- Guard prevents accidental rings while typing in `<input>`, `<select>`, `<textarea>`, or `<button>` elements
- Monospace `[Space / Enter]` hint rendered directly below the Ring button using `var(--text-muted)`, `'Courier New'`, `11px`, `uppercase`, `letter-spacing: 0.08em`
- `web/index.html` and `docs/index.html` kept byte-identical

## Test plan

- [ ] Press Space while page is focused (no element active) — ring fires
- [ ] Press Enter while page is focused (no element active) — ring fires
- [ ] Click into MQTT broker URL input, press Space — ring does NOT fire
- [ ] Focus the Mode `<select>`, press Enter — ring does NOT fire
- [ ] Keyboard hint `[Space / Enter]` visible beneath Ring button in all three themes (Light / Neutral / Dark)
- [ ] No border-radius or box-shadow introduced

Closes #21


---
_Generated by [Claude Code](https://claude.ai/code/session_0134zdk82bGBzUy47k77voCv)_