### PR TITLE
feat: 67Hz dog hearing floor marker in FFT spectrum (#22)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -937,6 +937,7 @@ function drawFFT() {
 
     // Dynamic markers: 40Hz + current secondary frequency
     const accent = getComputedStyle(document.documentElement).getPropertyValue('--accent').trim();
+    const mutedColor = getComputedStyle(document.documentElement).getPropertyValue('--text-muted').trim();
     const secFreq = currentSecondaryFreq;
     [[40, accent], [secFreq, '#FFBF00']].forEach(([f, color]) => {
       const x = Math.round(f / maxFreq * W);
@@ -946,6 +947,14 @@ function drawFFT() {
       ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
       ctx.setLineDash([]);
     });
+
+    // 67Hz dog hearing floor marker — dogs hear ≥67Hz; this line marks the threshold
+    const x67 = Math.round(67 / maxFreq * W);
+    ctx.strokeStyle = mutedColor;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath(); ctx.moveTo(x67, 0); ctx.lineTo(x67, H); ctx.stroke();
+    ctx.setLineDash([]);
 
     const barW = W / maxBin;
     const barIdle = getComputedStyle(document.documentElement).getPropertyValue('--bar-idle').trim();
@@ -967,6 +976,9 @@ function drawFFT() {
     ctx.fillStyle = '#FFBF00';
     const xSec = Math.round(secFreq / maxFreq * W);
     ctx.fillText(Math.round(secFreq) + 'Hz', Math.max(3, xSec - 20), 14);
+    // 67Hz label on second line to avoid overlap with the 40Hz label (only 27Hz apart)
+    ctx.fillStyle = mutedColor;
+    ctx.fillText('67Hz DOG ↓', x67 + 3, 28);
   }
   draw();
 }

--- a/web/index.html
+++ b/web/index.html
@@ -937,6 +937,7 @@ function drawFFT() {
 
     // Dynamic markers: 40Hz + current secondary frequency
     const accent = getComputedStyle(document.documentElement).getPropertyValue('--accent').trim();
+    const mutedColor = getComputedStyle(document.documentElement).getPropertyValue('--text-muted').trim();
     const secFreq = currentSecondaryFreq;
     [[40, accent], [secFreq, '#FFBF00']].forEach(([f, color]) => {
       const x = Math.round(f / maxFreq * W);
@@ -946,6 +947,14 @@ function drawFFT() {
       ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
       ctx.setLineDash([]);
     });
+
+    // 67Hz dog hearing floor marker — dogs hear ≥67Hz; this line marks the threshold
+    const x67 = Math.round(67 / maxFreq * W);
+    ctx.strokeStyle = mutedColor;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath(); ctx.moveTo(x67, 0); ctx.lineTo(x67, H); ctx.stroke();
+    ctx.setLineDash([]);
 
     const barW = W / maxBin;
     const barIdle = getComputedStyle(document.documentElement).getPropertyValue('--bar-idle').trim();
@@ -967,6 +976,9 @@ function drawFFT() {
     ctx.fillStyle = '#FFBF00';
     const xSec = Math.round(secFreq / maxFreq * W);
     ctx.fillText(Math.round(secFreq) + 'Hz', Math.max(3, xSec - 20), 14);
+    // 67Hz label on second line to avoid overlap with the 40Hz label (only 27Hz apart)
+    ctx.fillStyle = mutedColor;
+    ctx.fillText('67Hz DOG ↓', x67 + 3, 28);
   }
   draw();
 }


### PR DESCRIPTION
## Summary

- Draws a dashed vertical line at 67Hz using `var(--text-muted)` and `setLineDash([4, 4])`, clearly distinguishing it from the solid-coloured 40Hz (orange) and secondary-freq (amber) markers
- Labels the line `67Hz DOG ↓` on the second label row (y=28) to avoid collision with the `40Hz` label at y=14 — these two frequencies are only 27Hz apart on the 0–4000Hz canvas axis
- Reads `--text-muted` once per animation frame alongside the existing `--canvas-bg` and `--bar-idle` reads, so it honours theme switches (Light / Neutral / Dark) correctly
- No new CSS classes needed — all drawing is on-canvas; no border-radius, no box-shadow
- `web/index.html` and `docs/index.html` kept byte-identical

## Why it matters

The 67Hz dog hearing floor is the product's entire value proposition. Showing it as a visible threshold on the same spectrum where the 40Hz bar appears makes that claim immediately self-evident — no need to read the explainer section.

## Test plan

- [ ] Ring HushBell — orange 40Hz bar appears left of the dashed `67Hz DOG ↓` line
- [ ] `67Hz DOG ↓` label visible in all three themes without colour clash
- [ ] Line is dashed [4,4], distinct from the [3,3] dashes used for 40Hz and secondary markers
- [ ] No overlap between `40Hz` (y=14) and `67Hz DOG ↓` (y=28) labels
- [ ] Resize browser window — canvas ResizeObserver reflows correctly, marker tracks to correct x position

Closes #22


---
_Generated by [Claude Code](https://claude.ai/code/session_0134zdk82bGBzUy47k77voCv)_