### PR TITLE
feat: master volume control slider (#23)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -464,6 +464,11 @@
           <option value="on">On (harmonics + vibrato)</option>
         </select>
       </div>
+      <div class="freq-row">
+        <label>Volume</label>
+        <input type="range" id="volumeSlider" min="0" max="100" value="70" oninput="updateVolume()">
+        <span class="range-val" id="volumeVal">70%</span>
+      </div>
 
       <div id="randomControls" class="sub-controls">
         <div class="freq-row">
@@ -651,6 +656,7 @@ const MAX_RINGS = 1200;
 let ringsLeft = MAX_RINGS;
 let audioCtx = null;
 let analyser = null;
+let masterGain = null;
 let rafId = null;
 let isRinging = false;
 let currentSecondaryFreq = 2000;
@@ -664,7 +670,10 @@ function initAudio() {
   analyser = audioCtx.createAnalyser();
   analyser.fftSize = 2048;
   analyser.smoothingTimeConstant = 0.75;
-  analyser.connect(audioCtx.destination);
+  masterGain = audioCtx.createGain();
+  masterGain.gain.value = parseInt(document.getElementById('volumeSlider').value) / 100;
+  analyser.connect(masterGain);
+  masterGain.connect(audioCtx.destination);
   drawFFT();
 }
 
@@ -832,6 +841,12 @@ function updateRangeLabel(inputId, labelId) {
   const val = document.getElementById(inputId).value;
   const el = document.getElementById(labelId);
   el.textContent = labelId.includes('Spread') ? '+/- ' + val : val + ' Hz';
+}
+
+function updateVolume() {
+  const val = parseInt(document.getElementById('volumeSlider').value);
+  document.getElementById('volumeVal').textContent = val + '%';
+  if (masterGain) masterGain.gain.value = val / 100;
 }
 
 function initPresetChips() {

--- a/web/index.html
+++ b/web/index.html
@@ -464,6 +464,11 @@
           <option value="on">On (harmonics + vibrato)</option>
         </select>
       </div>
+      <div class="freq-row">
+        <label>Volume</label>
+        <input type="range" id="volumeSlider" min="0" max="100" value="70" oninput="updateVolume()">
+        <span class="range-val" id="volumeVal">70%</span>
+      </div>
 
       <div id="randomControls" class="sub-controls">
         <div class="freq-row">
@@ -651,6 +656,7 @@ const MAX_RINGS = 1200;
 let ringsLeft = MAX_RINGS;
 let audioCtx = null;
 let analyser = null;
+let masterGain = null;
 let rafId = null;
 let isRinging = false;
 let currentSecondaryFreq = 2000;
@@ -664,7 +670,10 @@ function initAudio() {
   analyser = audioCtx.createAnalyser();
   analyser.fftSize = 2048;
   analyser.smoothingTimeConstant = 0.75;
-  analyser.connect(audioCtx.destination);
+  masterGain = audioCtx.createGain();
+  masterGain.gain.value = parseInt(document.getElementById('volumeSlider').value) / 100;
+  analyser.connect(masterGain);
+  masterGain.connect(audioCtx.destination);
   drawFFT();
 }
 
@@ -832,6 +841,12 @@ function updateRangeLabel(inputId, labelId) {
   const val = document.getElementById(inputId).value;
   const el = document.getElementById(labelId);
   el.textContent = labelId.includes('Spread') ? '+/- ' + val : val + ' Hz';
+}
+
+function updateVolume() {
+  const val = parseInt(document.getElementById('volumeSlider').value);
+  document.getElementById('volumeVal').textContent = val + '%';
+  if (masterGain) masterGain.gain.value = val / 100;
 }
 
 function initPresetChips() {


### PR DESCRIPTION
## Summary

- Inserts a `GainNode` (`masterGain`) between `AnalyserNode` and `destination` so all oscillators (40Hz, secondary, harmonic, vibrato LFO) are scaled together without touching individual oscillator gains
- Volume slider (range 0–100, default **70%**) added to the Frequency Mode card using the existing `.freq-row` / `.range-val` layout — no new CSS classes required
- `updateVolume()` sets `masterGain.gain.value` immediately when the slider moves if the `AudioContext` is already live; the value is read from the slider on the first `initAudio()` call so lazy-init is safe
- `web/index.html` and `docs/index.html` kept byte-identical

## Test plan

- [ ] Page loads — Volume slider shows 70% default
- [ ] Drag slider to 0% — ring fires but no audio output
- [ ] Drag slider to 100% — ring fires at full gain
- [ ] Adjust slider mid-ring — gain updates immediately (no click or artifact)
- [ ] Swiss Nihilism: Courier New 13px label `Volume`, orange `var(--accent)` value display, existing `.freq-row` layout, no border-radius, no box-shadow
- [ ] All three themes (Light / Neutral / Dark) render the row correctly

Closes #23


---
_Generated by [Claude Code](https://claude.ai/code/session_0134zdk82bGBzUy47k77voCv)_