### PR TITLE
feat: timestamped ring history log panel (#24)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -373,6 +373,33 @@
     color: var(--accent); word-break: break-all;
   }
 
+  /* ─── RING HISTORY ───────────────────────── */
+  .history-header {
+    display: flex; justify-content: space-between; align-items: baseline;
+    margin-bottom: 10px;
+  }
+  .history-clear-btn {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--text-muted); background: transparent;
+    border: 1px solid var(--border); padding: 2px 8px; cursor: pointer;
+    transition: color 0.1s, border-color 0.1s;
+  }
+  .history-clear-btn:hover { color: var(--accent); border-color: var(--accent); }
+  .history-empty {
+    font-family: 'Courier New', Courier, monospace; font-size: 12px;
+    color: var(--text-muted); padding: 6px 0;
+  }
+  .history-row {
+    font-family: 'Courier New', Courier, monospace; font-size: 12px;
+    padding: 5px 0; border-bottom: 1px solid var(--border);
+    display: flex; gap: 10px; flex-wrap: wrap; align-items: baseline;
+  }
+  .history-row:last-child { border-bottom: none; }
+  .history-ts { color: var(--text-muted); flex-shrink: 0; }
+  .history-freq { color: var(--accent); font-weight: 700; }
+  .history-meta { color: var(--text); }
+
   /* ─── RING SIGIL ──────────────────────────── */
   /* Deterministic ASCII fingerprint per ring — same payload, same sigil, byte-for-byte. */
   .sigil-stack { display: flex; flex-direction: column; }
@@ -585,6 +612,15 @@
   <div class="card">
     <div class="card-label">Ring Sigil — Frequency Fingerprint</div>
     <div class="sigil-stack" id="sigilStack"></div>
+  </div>
+
+  <!-- Ring History Log -->
+  <div class="card">
+    <div class="history-header">
+      <div class="card-label" style="margin-bottom:0">Ring History — Last 10 Rings</div>
+      <button class="history-clear-btn" onclick="clearRingHistory()">[Clear]</button>
+    </div>
+    <div id="ringHistoryLog"><div class="history-empty">No rings yet.</div></div>
   </div>
 
   <!-- Emergent: Comparison -->
@@ -818,6 +854,7 @@ function handleRing() {
   // web sigil and the hardware-echo sigil (rendered from the int the ESP32 received)
   // are byte-identical on an honest round-trip — the feature's whole point.
   renderSigil(Math.round(currentSecondaryFreq), envType, isPleasant, false);
+  addToRingHistory(Math.round(currentSecondaryFreq), mode, envType);
 }
 
 // ─── Frequency mode UI switching ──────────────────────────────────────────────
@@ -1122,6 +1159,40 @@ async function shareHushBell() {
     }
   }
   setTimeout(() => { status.textContent = ''; }, 3000);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RING HISTORY — timestamped log of last 10 rings (session only)
+// ═══════════════════════════════════════════════════════════════════════════════
+const ringHistory = [];
+
+function addToRingHistory(freq, mode, env) {
+  const now = new Date();
+  const ts = now.toTimeString().slice(0, 8);
+  ringHistory.unshift({ ts, freq, mode, env });
+  if (ringHistory.length > 10) ringHistory.length = 10;
+  renderRingHistory();
+}
+
+function renderRingHistory() {
+  const log = document.getElementById('ringHistoryLog');
+  if (!log) return;
+  if (ringHistory.length === 0) {
+    log.innerHTML = '<div class="history-empty">No rings yet.</div>';
+    return;
+  }
+  log.innerHTML = ringHistory.map(r =>
+    `<div class="history-row">` +
+    `<span class="history-ts">${r.ts}</span>` +
+    `<span class="history-freq">${r.freq}Hz</span>` +
+    `<span class="history-meta">${r.mode} / ${r.env}</span>` +
+    `</div>`
+  ).join('');
+}
+
+function clearRingHistory() {
+  ringHistory.length = 0;
+  renderRingHistory();
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/web/index.html
+++ b/web/index.html
@@ -373,6 +373,33 @@
     color: var(--accent); word-break: break-all;
   }
 
+  /* ─── RING HISTORY ───────────────────────── */
+  .history-header {
+    display: flex; justify-content: space-between; align-items: baseline;
+    margin-bottom: 10px;
+  }
+  .history-clear-btn {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--text-muted); background: transparent;
+    border: 1px solid var(--border); padding: 2px 8px; cursor: pointer;
+    transition: color 0.1s, border-color 0.1s;
+  }
+  .history-clear-btn:hover { color: var(--accent); border-color: var(--accent); }
+  .history-empty {
+    font-family: 'Courier New', Courier, monospace; font-size: 12px;
+    color: var(--text-muted); padding: 6px 0;
+  }
+  .history-row {
+    font-family: 'Courier New', Courier, monospace; font-size: 12px;
+    padding: 5px 0; border-bottom: 1px solid var(--border);
+    display: flex; gap: 10px; flex-wrap: wrap; align-items: baseline;
+  }
+  .history-row:last-child { border-bottom: none; }
+  .history-ts { color: var(--text-muted); flex-shrink: 0; }
+  .history-freq { color: var(--accent); font-weight: 700; }
+  .history-meta { color: var(--text); }
+
   /* ─── RING SIGIL ──────────────────────────── */
   /* Deterministic ASCII fingerprint per ring — same payload, same sigil, byte-for-byte. */
   .sigil-stack { display: flex; flex-direction: column; }
@@ -585,6 +612,15 @@
   <div class="card">
     <div class="card-label">Ring Sigil — Frequency Fingerprint</div>
     <div class="sigil-stack" id="sigilStack"></div>
+  </div>
+
+  <!-- Ring History Log -->
+  <div class="card">
+    <div class="history-header">
+      <div class="card-label" style="margin-bottom:0">Ring History — Last 10 Rings</div>
+      <button class="history-clear-btn" onclick="clearRingHistory()">[Clear]</button>
+    </div>
+    <div id="ringHistoryLog"><div class="history-empty">No rings yet.</div></div>
   </div>
 
   <!-- Emergent: Comparison -->
@@ -818,6 +854,7 @@ function handleRing() {
   // web sigil and the hardware-echo sigil (rendered from the int the ESP32 received)
   // are byte-identical on an honest round-trip — the feature's whole point.
   renderSigil(Math.round(currentSecondaryFreq), envType, isPleasant, false);
+  addToRingHistory(Math.round(currentSecondaryFreq), mode, envType);
 }
 
 // ─── Frequency mode UI switching ──────────────────────────────────────────────
@@ -1122,6 +1159,40 @@ async function shareHushBell() {
     }
   }
   setTimeout(() => { status.textContent = ''; }, 3000);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RING HISTORY — timestamped log of last 10 rings (session only)
+// ═══════════════════════════════════════════════════════════════════════════════
+const ringHistory = [];
+
+function addToRingHistory(freq, mode, env) {
+  const now = new Date();
+  const ts = now.toTimeString().slice(0, 8);
+  ringHistory.unshift({ ts, freq, mode, env });
+  if (ringHistory.length > 10) ringHistory.length = 10;
+  renderRingHistory();
+}
+
+function renderRingHistory() {
+  const log = document.getElementById('ringHistoryLog');
+  if (!log) return;
+  if (ringHistory.length === 0) {
+    log.innerHTML = '<div class="history-empty">No rings yet.</div>';
+    return;
+  }
+  log.innerHTML = ringHistory.map(r =>
+    `<div class="history-row">` +
+    `<span class="history-ts">${r.ts}</span>` +
+    `<span class="history-freq">${r.freq}Hz</span>` +
+    `<span class="history-meta">${r.mode} / ${r.env}</span>` +
+    `</div>`
+  ).join('');
+}
+
+function clearRingHistory() {
+  ringHistory.length = 0;
+  renderRingHistory();
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Session-only `ringHistory` array (no persistence) stores up to 10 ring events; oldest trimmed automatically after each ring
- Each row shows: `HH:MM:SS` timestamp (`var(--text-muted)`), frequency in Hz (`var(--accent)` bold), mode and envelope type (`var(--text)`)
- Newest ring is prepended at top so the latest is always visible without scrolling
- `[Clear]` button in the card header resets the log in-place
- `addToRingHistory()` is called from `handleRing()` alongside `renderSigil()`, using the same `Math.round(currentSecondaryFreq)` value published to MQTT — consistent with the sigil fingerprint
- Swiss Nihilism: Courier New 12px rows, `1px solid var(--border)` row separators, no border-radius, no box-shadow; clear button outline shifts from `var(--border)` to `var(--accent)` on hover
- `web/index.html` and `docs/index.html` kept byte-identical

## Test plan

- [ ] On page load: card shows "No rings yet."
- [ ] Ring once — row appears: `HH:MM:SS · {freq}Hz · {mode} / {env}`
- [ ] Ring 11 times — only 10 rows shown (11th oldest dropped)
- [ ] Click `[Clear]` — log resets to "No rings yet." without reload
- [ ] Switch theme — row colours follow `var(--text-muted)`, `var(--accent)`, `var(--border)` correctly
- [ ] No border-radius, no box-shadow introduced

Closes #24


---
_Generated by [Claude Code](https://claude.ai/code/session_0134zdk82bGBzUy47k77voCv)_