### PR TITLE
feat: keyboard shortcut (Space/Enter) to ring HushBell (#21)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -199,6 +199,16 @@
   .ring-btn:active { opacity: 0.85; }
   .ring-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
+  .ring-hint {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    text-align: center;
+    margin-top: 4px;
+  }
+
   /* ─── FREQUENCY CONTROLS ───────────────────── */
   .freq-controls { display: flex; flex-direction: column; gap: 12px; }
 
@@ -532,6 +542,7 @@
 
   <!-- Ring Button -->
   <button class="ring-btn" id="ringBtn" onclick="handleRing()">&#x25B6; Ring HushBell</button>
+  <div class="ring-hint">[SPACE / ENTER]</div>
 
   <!-- Emergent: Battery Projection -->
   <div class="emergent-card projection" id="ec-projection">
@@ -1355,6 +1366,17 @@ async function mqttToggle() {
     mqtt.subscribe(['hushbell/status', 'hushbell/battery', 'hushbell/config/state']);
   } catch { /* onStateChange('error') already drove the UI */ }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// KEYBOARD SHORTCUTS — Space / Enter rings HushBell when no form control is focused
+// ═══════════════════════════════════════════════════════════════════════════════
+document.addEventListener('keydown', e => {
+  if (e.code !== 'Space' && e.code !== 'Enter') return;
+  const tag = document.activeElement && document.activeElement.tagName;
+  if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+  e.preventDefault();
+  handleRing();
+});
 
 // ─── Init ─────────────────────────────────────────────────────────────────────
 initPresetChips();

--- a/web/index.html
+++ b/web/index.html
@@ -199,6 +199,16 @@
   .ring-btn:active { opacity: 0.85; }
   .ring-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
+  .ring-hint {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    text-align: center;
+    margin-top: 4px;
+  }
+
   /* ─── FREQUENCY CONTROLS ───────────────────── */
   .freq-controls { display: flex; flex-direction: column; gap: 12px; }
 
@@ -532,6 +542,7 @@
 
   <!-- Ring Button -->
   <button class="ring-btn" id="ringBtn" onclick="handleRing()">&#x25B6; Ring HushBell</button>
+  <div class="ring-hint">[SPACE / ENTER]</div>
 
   <!-- Emergent: Battery Projection -->
   <div class="emergent-card projection" id="ec-projection">
@@ -1355,6 +1366,17 @@ async function mqttToggle() {
     mqtt.subscribe(['hushbell/status', 'hushbell/battery', 'hushbell/config/state']);
   } catch { /* onStateChange('error') already drove the UI */ }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// KEYBOARD SHORTCUTS — Space / Enter rings HushBell when no form control is focused
+// ═══════════════════════════════════════════════════════════════════════════════
+document.addEventListener('keydown', e => {
+  if (e.code !== 'Space' && e.code !== 'Enter') return;
+  const tag = document.activeElement && document.activeElement.tagName;
+  if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+  e.preventDefault();
+  handleRing();
+});
 
 // ─── Init ─────────────────────────────────────────────────────────────────────
 initPresetChips();


### PR DESCRIPTION
## Summary

Closes #21.

- **Space** and **Enter** now trigger `handleRing()` from anywhere on the page, enabling power-user and screen-reader access without moving to the mouse.
- Guard prevents accidental rings when focus is inside `<input>`, `<select>`, or `<textarea>` (e.g. the MQTT broker URL field).
- `[SPACE / ENTER]` hint rendered beneath the Ring button in Swiss Nihilism monospace style: `'Courier New'`, 11px, uppercase, `letter-spacing: 0.08em`, `color: var(--text-muted)`. No border-radius, no box-shadow.

Both `web/index.html` and `docs/index.html` updated identically.

## Test plan

- [ ] Open demo in browser, do NOT focus any input — press Space, confirm ring fires (LED chase + audio)
- [ ] Press Enter with no focus — confirm ring fires
- [ ] Click the MQTT Broker URL field, press Space — confirm NO ring fires
- [ ] Click the Mode dropdown, press Enter — confirm NO ring fires
- [ ] Verify `[SPACE / ENTER]` hint is visible beneath the Ring button in all 3 themes (Light / Neutral / Dark)
- [ ] Verify hint uses `--text-muted` colour and disappears into background when battery is empty (button disabled — keyboard shortcut still guards via `isRinging` + `ringsLeft <= 0` inside `handleRing()`)
- [ ] `diff docs/index.html web/index.html` returns empty (files are byte-identical)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEm7PJ341jwsnUQ9Q76QnD)_