### PR TITLE
feat: 67Hz dog hearing floor marker in FFT spectrum (#22)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -947,6 +947,15 @@ function drawFFT() {
       ctx.setLineDash([]);
     });
 
+    // 67Hz dog hearing floor marker — neutral dashed line, [4,4] to distinguish from 40Hz/secondary
+    const textMuted = getComputedStyle(document.documentElement).getPropertyValue('--text-muted').trim();
+    const x67 = Math.round(67 / maxFreq * W);
+    ctx.strokeStyle = textMuted;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath(); ctx.moveTo(x67, 0); ctx.lineTo(x67, H); ctx.stroke();
+    ctx.setLineDash([]);
+
     const barW = W / maxBin;
     const barIdle = getComputedStyle(document.documentElement).getPropertyValue('--bar-idle').trim();
     for (let i = 0; i < maxBin; i++) {
@@ -967,6 +976,8 @@ function drawFFT() {
     ctx.fillStyle = '#FFBF00';
     const xSec = Math.round(secFreq / maxFreq * W);
     ctx.fillText(Math.round(secFreq) + 'Hz', Math.max(3, xSec - 20), 14);
+    ctx.fillStyle = textMuted;
+    ctx.fillText('67Hz DOG ↓', x67 + 3, 14);
   }
   draw();
 }

--- a/web/index.html
+++ b/web/index.html
@@ -947,6 +947,15 @@ function drawFFT() {
       ctx.setLineDash([]);
     });
 
+    // 67Hz dog hearing floor marker — neutral dashed line, [4,4] to distinguish from 40Hz/secondary
+    const textMuted = getComputedStyle(document.documentElement).getPropertyValue('--text-muted').trim();
+    const x67 = Math.round(67 / maxFreq * W);
+    ctx.strokeStyle = textMuted;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath(); ctx.moveTo(x67, 0); ctx.lineTo(x67, H); ctx.stroke();
+    ctx.setLineDash([]);
+
     const barW = W / maxBin;
     const barIdle = getComputedStyle(document.documentElement).getPropertyValue('--bar-idle').trim();
     for (let i = 0; i < maxBin; i++) {
@@ -967,6 +976,8 @@ function drawFFT() {
     ctx.fillStyle = '#FFBF00';
     const xSec = Math.round(secFreq / maxFreq * W);
     ctx.fillText(Math.round(secFreq) + 'Hz', Math.max(3, xSec - 20), 14);
+    ctx.fillStyle = textMuted;
+    ctx.fillText('67Hz DOG ↓', x67 + 3, 14);
   }
   draw();
 }


### PR DESCRIPTION
## Summary

Closes #22.

- Vertical dashed line drawn at `x = (67 / maxFreq) * W` on every frame of the FFT canvas.
- Line style: `setLineDash([4, 4])` — distinct from the existing `[3, 3]` dashes on the 40Hz and secondary-freq markers.
- Colour: `var(--text-muted)` read via `getComputedStyle` so it responds to theme switching at 60fps.
- Label: `'67Hz DOG ↓'` at canvas top in `'Courier New' 11px`, same y-offset as the existing 40Hz / secondary labels.
- Makes the product's core value prop immediately legible: the 40Hz orange bar sits clearly to the left of the 67Hz threshold.

Both `web/index.html` and `docs/index.html` updated identically. No border-radius, no box-shadow added.

## Test plan

- [ ] Open demo, ring once — verify `67Hz DOG ↓` label appears near left edge of FFT canvas, distinct from the orange `40Hz` label and the amber secondary-freq label
- [ ] Switch through all 3 themes (Light / Neutral / Dark) — verify the 67Hz line colour adapts with `--text-muted` (dark grey / warm brown / mid-grey)
- [ ] Confirm 67Hz dashes are `[4,4]` pattern (slightly longer gaps than the `[3,3]` on the tone markers)
- [ ] Resize the browser window — verify line x-position scales with canvas width via `ResizeObserver`
- [ ] `diff docs/index.html web/index.html` returns empty (files are byte-identical)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEm7PJ341jwsnUQ9Q76QnD)_