### PR TITLE
feat: master volume control slider (#23)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -464,6 +464,11 @@
           <option value="on">On (harmonics + vibrato)</option>
         </select>
       </div>
+      <div class="freq-row">
+        <label>Volume</label>
+        <input type="range" id="masterVol" min="0" max="100" value="70" oninput="updateMasterVolume(this.value)">
+        <span class="range-val" id="masterVolVal">70%</span>
+      </div>
 
       <div id="randomControls" class="sub-controls">
         <div class="freq-row">
@@ -651,6 +656,7 @@ const MAX_RINGS = 1200;
 let ringsLeft = MAX_RINGS;
 let audioCtx = null;
 let analyser = null;
+let masterGain = null;
 let rafId = null;
 let isRinging = false;
 let currentSecondaryFreq = 2000;
@@ -664,8 +670,16 @@ function initAudio() {
   analyser = audioCtx.createAnalyser();
   analyser.fftSize = 2048;
   analyser.smoothingTimeConstant = 0.75;
-  analyser.connect(audioCtx.destination);
+  masterGain = audioCtx.createGain();
+  masterGain.gain.value = parseInt(document.getElementById('masterVol').value) / 100;
+  analyser.connect(masterGain);
+  masterGain.connect(audioCtx.destination);
   drawFFT();
+}
+
+function updateMasterVolume(val) {
+  document.getElementById('masterVolVal').textContent = val + '%';
+  if (masterGain) masterGain.gain.value = val / 100;
 }
 
 // ─── Frequency resolution (mirrors Python resolve_secondary_freq) ────────────

--- a/web/index.html
+++ b/web/index.html
@@ -464,6 +464,11 @@
           <option value="on">On (harmonics + vibrato)</option>
         </select>
       </div>
+      <div class="freq-row">
+        <label>Volume</label>
+        <input type="range" id="masterVol" min="0" max="100" value="70" oninput="updateMasterVolume(this.value)">
+        <span class="range-val" id="masterVolVal">70%</span>
+      </div>
 
       <div id="randomControls" class="sub-controls">
         <div class="freq-row">
@@ -651,6 +656,7 @@ const MAX_RINGS = 1200;
 let ringsLeft = MAX_RINGS;
 let audioCtx = null;
 let analyser = null;
+let masterGain = null;
 let rafId = null;
 let isRinging = false;
 let currentSecondaryFreq = 2000;
@@ -664,8 +670,16 @@ function initAudio() {
   analyser = audioCtx.createAnalyser();
   analyser.fftSize = 2048;
   analyser.smoothingTimeConstant = 0.75;
-  analyser.connect(audioCtx.destination);
+  masterGain = audioCtx.createGain();
+  masterGain.gain.value = parseInt(document.getElementById('masterVol').value) / 100;
+  analyser.connect(masterGain);
+  masterGain.connect(audioCtx.destination);
   drawFFT();
+}
+
+function updateMasterVolume(val) {
+  document.getElementById('masterVolVal').textContent = val + '%';
+  if (masterGain) masterGain.gain.value = val / 100;
 }
 
 // ─── Frequency resolution (mirrors Python resolve_secondary_freq) ────────────


### PR DESCRIPTION
## Summary

Closes #23.

- Adds a `masterGain` (`GainNode`) inserted between `AnalyserNode` and `destination` so all oscillators pass through a single, controllable output stage.
- Range slider: 0–100, default 70, displayed as `{n}%` in `var(--accent)` using the existing `.range-val` style.
- All existing oscillator gains (`gain40 = 0.6`, `gainSec = 0.4`, `gainHarm = 0.06`) are unchanged — only the master node scales final output.
- AudioContext remains lazy-init (first ring); `masterGain` reads the slider at that moment and stays in sync via `updateMasterVolume()`.
- Uses existing `.freq-row` layout — no new CSS required, no border-radius, no box-shadow.

Both `web/index.html` and `docs/index.html` updated identically.

## Test plan

- [ ] Open demo, slide Volume to 0% — ring HushBell, confirm silence (LEDs still animate)
- [ ] Slide Volume to 100% — ring, confirm full volume output
- [ ] Slide Volume to 50% — confirm audible reduction compared to 100%
- [ ] Ring at 70% (default), then adjust slider mid-session — confirm gain changes take effect on the next ring without any AudioContext re-init
- [ ] Reload page — confirm slider defaults to 70%
- [ ] Inspect audio graph in browser DevTools: confirm `AnalyserNode → GainNode → AudioDestinationNode` chain
- [ ] `diff docs/index.html web/index.html` returns empty (files are byte-identical)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEm7PJ341jwsnUQ9Q76QnD)_