### PR TITLE
feat(#21): keyboard shortcut (Space/Enter) to ring HushBell

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -373,6 +373,17 @@
     color: var(--accent); word-break: break-all;
   }
 
+  /* ─── KEYBOARD HINT ────────────────────────── */
+  .kbd-hint {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    text-align: center;
+    margin-top: 6px;
+  }
+
   /* ─── RING SIGIL ──────────────────────────── */
   /* Deterministic ASCII fingerprint per ring — same payload, same sigil, byte-for-byte. */
   .sigil-stack { display: flex; flex-direction: column; }
@@ -532,6 +543,7 @@
 
   <!-- Ring Button -->
   <button class="ring-btn" id="ringBtn" onclick="handleRing()">&#x25B6; Ring HushBell</button>
+  <div class="kbd-hint">[SPACE / ENTER]</div>
 
   <!-- Emergent: Battery Projection -->
   <div class="emergent-card projection" id="ec-projection">
@@ -1355,6 +1367,15 @@ async function mqttToggle() {
     mqtt.subscribe(['hushbell/status', 'hushbell/battery', 'hushbell/config/state']);
   } catch { /* onStateChange('error') already drove the UI */ }
 }
+
+// ─── Keyboard shortcut: Space / Enter rings when no form control has focus ────
+document.addEventListener('keydown', function(e) {
+  if (e.code !== 'Space' && e.code !== 'Enter') return;
+  const tag = document.activeElement ? document.activeElement.tagName : '';
+  if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+  e.preventDefault();
+  handleRing();
+});
 
 // ─── Init ─────────────────────────────────────────────────────────────────────
 initPresetChips();

--- a/web/index.html
+++ b/web/index.html
@@ -373,6 +373,17 @@
     color: var(--accent); word-break: break-all;
   }
 
+  /* ─── KEYBOARD HINT ────────────────────────── */
+  .kbd-hint {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    text-align: center;
+    margin-top: 6px;
+  }
+
   /* ─── RING SIGIL ──────────────────────────── */
   /* Deterministic ASCII fingerprint per ring — same payload, same sigil, byte-for-byte. */
   .sigil-stack { display: flex; flex-direction: column; }
@@ -532,6 +543,7 @@
 
   <!-- Ring Button -->
   <button class="ring-btn" id="ringBtn" onclick="handleRing()">&#x25B6; Ring HushBell</button>
+  <div class="kbd-hint">[SPACE / ENTER]</div>
 
   <!-- Emergent: Battery Projection -->
   <div class="emergent-card projection" id="ec-projection">
@@ -1355,6 +1367,15 @@ async function mqttToggle() {
     mqtt.subscribe(['hushbell/status', 'hushbell/battery', 'hushbell/config/state']);
   } catch { /* onStateChange('error') already drove the UI */ }
 }
+
+// ─── Keyboard shortcut: Space / Enter rings when no form control has focus ────
+document.addEventListener('keydown', function(e) {
+  if (e.code !== 'Space' && e.code !== 'Enter') return;
+  const tag = document.activeElement ? document.activeElement.tagName : '';
+  if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+  e.preventDefault();
+  handleRing();
+});
 
 // ─── Init ─────────────────────────────────────────────────────────────────────
 initPresetChips();


### PR DESCRIPTION
## Summary

Closes #21.

- Space or Enter triggers `handleRing()` when no form control is focused
- Guard: fires are suppressed when `document.activeElement` is `INPUT`, `SELECT`, or `TEXTAREA` — MQTT broker URL edits are safe
- Monospace `[SPACE / ENTER]` hint rendered below the Ring button in Swiss Nihilism style (`'Courier New'`, 11px, uppercase, `--text-muted`)

## Design tokens used

- `font-family: 'Courier New', Courier, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted)`
- No border-radius, no box-shadow

## Files changed

- `web/index.html` — CSS `.kbd-hint`, HTML hint div, JS `keydown` listener
- `docs/index.html` — kept identical to `web/index.html`

## Test plan

- [ ] Click away from any input and press Space → ring fires
- [ ] Click away from any input and press Enter → ring fires
- [ ] Click inside MQTT broker URL input and press Space/Enter → no ring
- [ ] Click inside Mode select and press Space/Enter → no ring (select consumes it natively anyway)
- [ ] `[SPACE / ENTER]` hint visible below ring button in all three themes (light, neutral, dark)

---
_Generated by [Claude Code](https://claude.ai/code/session_019GAYqT5c73AJnkZPtcUP4J)_