### PR TITLE
feat(#22): 67Hz dog hearing floor marker in FFT spectrum canvas

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -947,6 +947,15 @@ function drawFFT() {
       ctx.setLineDash([]);
     });
 
+    // 67Hz dog hearing floor marker — dashed [4,4], text-muted, neutral
+    const textMuted = getComputedStyle(document.documentElement).getPropertyValue('--text-muted').trim();
+    const x67 = Math.round(67 / maxFreq * W);
+    ctx.strokeStyle = textMuted;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath(); ctx.moveTo(x67, 0); ctx.lineTo(x67, H); ctx.stroke();
+    ctx.setLineDash([]);
+
     const barW = W / maxBin;
     const barIdle = getComputedStyle(document.documentElement).getPropertyValue('--bar-idle').trim();
     for (let i = 0; i < maxBin; i++) {
@@ -967,6 +976,8 @@ function drawFFT() {
     ctx.fillStyle = '#FFBF00';
     const xSec = Math.round(secFreq / maxFreq * W);
     ctx.fillText(Math.round(secFreq) + 'Hz', Math.max(3, xSec - 20), 14);
+    ctx.fillStyle = textMuted;
+    ctx.fillText('67Hz DOG ↓', x67 + 3, 26);
   }
   draw();
 }

--- a/web/index.html
+++ b/web/index.html
@@ -947,6 +947,15 @@ function drawFFT() {
       ctx.setLineDash([]);
     });
 
+    // 67Hz dog hearing floor marker — dashed [4,4], text-muted, neutral
+    const textMuted = getComputedStyle(document.documentElement).getPropertyValue('--text-muted').trim();
+    const x67 = Math.round(67 / maxFreq * W);
+    ctx.strokeStyle = textMuted;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath(); ctx.moveTo(x67, 0); ctx.lineTo(x67, H); ctx.stroke();
+    ctx.setLineDash([]);
+
     const barW = W / maxBin;
     const barIdle = getComputedStyle(document.documentElement).getPropertyValue('--bar-idle').trim();
     for (let i = 0; i < maxBin; i++) {
@@ -967,6 +976,8 @@ function drawFFT() {
     ctx.fillStyle = '#FFBF00';
     const xSec = Math.round(secFreq / maxFreq * W);
     ctx.fillText(Math.round(secFreq) + 'Hz', Math.max(3, xSec - 20), 14);
+    ctx.fillStyle = textMuted;
+    ctx.fillText('67Hz DOG ↓', x67 + 3, 26);
   }
   draw();
 }


### PR DESCRIPTION
## Summary

Closes #22.

Draws a visible vertical dashed line at 67Hz inside the FFT canvas — the dog hearing floor. This makes the product's core value proposition immediately legible: the 40Hz orange bar sits left of the 67Hz threshold, i.e. below what dogs can perceive.

## What changed

- **Marker line**: `setLineDash([4, 4])`, `strokeStyle = var(--text-muted)`, drawn at `x = round(67 / maxFreq * W)` — neutral dash style that doesn't compete with the orange 40Hz or amber secondary-freq markers
- **Label**: `'67Hz DOG ↓'` in `Courier New` 11px at y=26 (one line below the 40Hz label at y=14) — avoids overlap since 40Hz and 67Hz are only ~0.7% apart on a 4kHz-wide canvas
- `textMuted` is resolved via `getComputedStyle` each frame so it responds correctly to theme switching

## Design tokens

- `font: '11px Courier New'`; `fillStyle: var(--text-muted)` — no border-radius, no box-shadow

## Files changed

- `web/index.html` — `drawFFT()` dynamic markers section + text label
- `docs/index.html` — kept identical

## Test plan

- [ ] Ring HushBell → dashed muted-colour vertical line appears near the left of the canvas, to the right of the 40Hz marker
- [ ] Label reads `67Hz DOG ↓` and does not overlap `40Hz`
- [ ] Switch between Light / Neutral / Dark themes → marker colour follows `--text-muted` for each theme
- [ ] Secondary-freq marker (amber) still renders correctly and independently

---
_Generated by [Claude Code](https://claude.ai/code/session_019GAYqT5c73AJnkZPtcUP4J)_