### PR TITLE
feat: keyboard shortcut Space/Enter to ring HushBell (#21)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -199,6 +199,16 @@
   .ring-btn:active { opacity: 0.85; }
   .ring-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
+  .kb-hint {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    text-align: center;
+    margin-top: 6px;
+  }
+
   /* ─── FREQUENCY CONTROLS ───────────────────── */
   .freq-controls { display: flex; flex-direction: column; gap: 12px; }
 
@@ -577,6 +587,7 @@
 
   <!-- Ring Button -->
   <button class="ring-btn" id="ringBtn" onclick="handleRing()">&#x25B6; Ring HushBell</button>
+  <div class="kb-hint">[SPACE / ENTER]</div>
 
   <!-- Emergent: Battery Projection -->
   <div class="emergent-card projection" id="ec-projection">
@@ -1459,6 +1470,15 @@ async function mqttToggle() {
     mqtt.subscribe(['hushbell/status', 'hushbell/battery', 'hushbell/config/state']);
   } catch { /* onStateChange('error') already drove the UI */ }
 }
+
+// ─── Keyboard shortcut — Space / Enter triggers ring (guards form controls) ────
+document.addEventListener('keydown', e => {
+  if (e.code !== 'Space' && e.code !== 'Enter') return;
+  const tag = document.activeElement && document.activeElement.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+  e.preventDefault();
+  handleRing();
+});
 
 // ─── Init ─────────────────────────────────────────────────────────────────────
 initPresetChips();

--- a/web/index.html
+++ b/web/index.html
@@ -199,6 +199,16 @@
   .ring-btn:active { opacity: 0.85; }
   .ring-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
+  .kb-hint {
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    text-align: center;
+    margin-top: 6px;
+  }
+
   /* ─── FREQUENCY CONTROLS ───────────────────── */
   .freq-controls { display: flex; flex-direction: column; gap: 12px; }
 
@@ -577,6 +587,7 @@
 
   <!-- Ring Button -->
   <button class="ring-btn" id="ringBtn" onclick="handleRing()">&#x25B6; Ring HushBell</button>
+  <div class="kb-hint">[SPACE / ENTER]</div>
 
   <!-- Emergent: Battery Projection -->
   <div class="emergent-card projection" id="ec-projection">
@@ -1459,6 +1470,15 @@ async function mqttToggle() {
     mqtt.subscribe(['hushbell/status', 'hushbell/battery', 'hushbell/config/state']);
   } catch { /* onStateChange('error') already drove the UI */ }
 }
+
+// ─── Keyboard shortcut — Space / Enter triggers ring (guards form controls) ────
+document.addEventListener('keydown', e => {
+  if (e.code !== 'Space' && e.code !== 'Enter') return;
+  const tag = document.activeElement && document.activeElement.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+  e.preventDefault();
+  handleRing();
+});
 
 // ─── Init ─────────────────────────────────────────────────────────────────────
 initPresetChips();


### PR DESCRIPTION
## Summary

Closes #21.

Adds keyboard shortcut support so power users and screen-reader users can trigger a ring without reaching for the mouse.

- **Space** or **Enter** calls `handleRing()` when no form control is focused
- Guard: skips firing when `document.activeElement` is `INPUT`, `TEXTAREA`, or `SELECT` — prevents accidental rings while editing the MQTT broker URL
- `[SPACE / ENTER]` hint rendered below the Ring button in Swiss Nihilism monospace style (`'Courier New', 11px, uppercase, letter-spacing: 0.08em, color: var(--text-muted)`)
- No `border-radius`, no `box-shadow` — design tokens unchanged

Both `web/index.html` and `docs/index.html` updated (kept identical).

## Test plan

- [ ] Press **Space** on a fresh page load → ring fires, LEDs animate, FFT responds
- [ ] Press **Enter** on a fresh page load → same behaviour
- [ ] Click into the MQTT Broker URL input, press **Space** → no ring, cursor advances in text field
- [ ] Click into the Mode `<select>`, press **Enter** → no ring, select opens/confirms
- [ ] Click the Ring button with mouse → still works (onclick path unchanged)
- [ ] Confirm `[SPACE / ENTER]` hint appears below the button in all three themes (Light / Neutral / Dark)
- [ ] Confirm hint uses `var(--text-muted)` and monospace uppercase styling

---
_Generated by [Claude Code](https://claude.ai/code/session_016bdyKAMsBjQXYxNRwzAfJQ)_