### PR TITLE
feat: 67Hz dog hearing floor marker in FFT spectrum canvas (#22)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1051,6 +1051,15 @@ function drawFFT() {
       ctx.setLineDash([]);
     });
 
+    // 67Hz dog hearing floor marker — [4,4] dash to distinguish from 40Hz/secondary [3,3]
+    const textMuted = getComputedStyle(document.documentElement).getPropertyValue('--text-muted').trim();
+    const x67 = Math.round(67 / maxFreq * W);
+    ctx.strokeStyle = textMuted;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath(); ctx.moveTo(x67, 0); ctx.lineTo(x67, H); ctx.stroke();
+    ctx.setLineDash([]);
+
     const barW = W / maxBin;
     const barIdle = getComputedStyle(document.documentElement).getPropertyValue('--bar-idle').trim();
     for (let i = 0; i < maxBin; i++) {
@@ -1071,6 +1080,8 @@ function drawFFT() {
     ctx.fillStyle = '#FFBF00';
     const xSec = Math.round(secFreq / maxFreq * W);
     ctx.fillText(Math.round(secFreq) + 'Hz', Math.max(3, xSec - 20), 14);
+    ctx.fillStyle = textMuted;
+    ctx.fillText('67Hz DOG ↓', x67 + 3, 26);
   }
   draw();
 }

--- a/web/index.html
+++ b/web/index.html
@@ -1051,6 +1051,15 @@ function drawFFT() {
       ctx.setLineDash([]);
     });
 
+    // 67Hz dog hearing floor marker — [4,4] dash to distinguish from 40Hz/secondary [3,3]
+    const textMuted = getComputedStyle(document.documentElement).getPropertyValue('--text-muted').trim();
+    const x67 = Math.round(67 / maxFreq * W);
+    ctx.strokeStyle = textMuted;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath(); ctx.moveTo(x67, 0); ctx.lineTo(x67, H); ctx.stroke();
+    ctx.setLineDash([]);
+
     const barW = W / maxBin;
     const barIdle = getComputedStyle(document.documentElement).getPropertyValue('--bar-idle').trim();
     for (let i = 0; i < maxBin; i++) {
@@ -1071,6 +1080,8 @@ function drawFFT() {
     ctx.fillStyle = '#FFBF00';
     const xSec = Math.round(secFreq / maxFreq * W);
     ctx.fillText(Math.round(secFreq) + 'Hz', Math.max(3, xSec - 20), 14);
+    ctx.fillStyle = textMuted;
+    ctx.fillText('67Hz DOG ↓', x67 + 3, 26);
   }
   draw();
 }


### PR DESCRIPTION
## Summary

Closes #22.

Draws a visible vertical dashed marker at 67Hz in the FFT canvas, making the product's core value proposition immediately legible: the 40Hz bar sits to the left of the 67Hz threshold — below what dogs can perceive.

### Implementation

- Vertical dashed line at `x = round(67 / maxFreq * W)` using `[4, 4]` dash pattern — distinct from the existing `[3, 3]` dashes on the 40Hz and secondary-freq markers
- Color: `var(--text-muted)` — neutral, does not compete with orange (40Hz) or amber (secondary)
- Label: `"67Hz DOG ↓"` in `'Courier New', 11px`, drawn at `y=26` (second line) to avoid horizontal overlap with the `40Hz` label at `y=14` — both fall within the first ~12px of the canvas at typical widths
- Touch-point: inside the `draw()` closure in `drawFFT()`, immediately after the 40Hz/secondary markers block

Both `web/index.html` and `docs/index.html` updated (kept identical).

No `border-radius`, no `box-shadow` — design tokens unchanged.

## Test plan

- [ ] Click Ring — observe the FFT canvas renders three vertical dashed lines: orange (40Hz), amber (secondary freq), muted (67Hz)
- [ ] Confirm the 67Hz line uses `[4, 4]` dash cadence, visually different from the `[3, 3]` cadence of 40Hz/secondary
- [ ] Confirm the label `67Hz DOG ↓` appears in the top-left of the canvas near the 67Hz line, in `var(--text-muted)` colour
- [ ] Verify the 40Hz label (`40Hz`) and 67Hz label do not overlap in Light, Neutral, and Dark themes
- [ ] Confirm label colour tracks `--text-muted` when switching themes (no hard-coded colour)
- [ ] Confirm the 40Hz orange bar visually sits to the left of the 67Hz muted line — the core product message

---
_Generated by [Claude Code](https://claude.ai/code/session_016bdyKAMsBjQXYxNRwzAfJQ)_